### PR TITLE
feat: Vote Ticker for Header and Footer (desktop, stub data)

### DIFF
--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -12,7 +12,7 @@ const Footer = () => {
   const { value, setValue } = useFooter();
   return (
     <>
-      <VoteTicker theme="light" />
+      <VoteTicker theme="light" numVotes={2} />
 
       <Section>
         <Wrapper>

--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -7,55 +7,60 @@ import Github from "public/assets/github.svg";
 import Discourse from "public/assets/discourse.svg";
 import BlackCircle from "public/assets/black-circle.svg";
 import UpRightArrowBlack from "public/assets/up-right-arrow-black.svg";
+import { VoteTicker } from "components";
 const Footer = () => {
   const { value, setValue } = useFooter();
   return (
-    <Section>
-      <Wrapper>
-        <BottomRow>
-          <FooterLinks>
-            <LogoWrapper>
-              <StyledLogo />
-            </LogoWrapper>
-            <LinksFlex>
-              <Links>
-                {middleLinks.map(({ label, href }, i) => (
-                  <Link key={i} href={href} target="_blank" rel="noreferrer">
-                    {label}
-                  </Link>
-                ))}
-              </Links>
-              <Links>
-                {rightLinks.map(({ label, href, Logo }, i) => (
-                  <Link key={i} href={href} target="_blank" rel="noreferrer">
-                    {label} {Logo && <Logo style={{ display: "inline-flex", marginLeft: "4px" }} />}
-                  </Link>
-                ))}
-              </Links>
-            </LinksFlex>
-          </FooterLinks>
-          <FormWrapper>
-            <FormTitle>Receive the latest UMA and OO news, straight to your inbox.</FormTitle>
-            <Form>
-              <Input value={value} onChange={(e) => setValue(e.target.value)} placeholder="jane@doe.com"></Input>
-              <Button onClick={() => null}>Sign up</Button>
-            </Form>
-          </FormWrapper>
-        </BottomRow>
-        <CopyrightRow>
-          <AddressWrapper>
-            <div>© 2022 Risk Labs</div>
-          </AddressWrapper>
-          <SocialLinks>
-            {socialLinks.map(({ href, Icon }, i) => (
-              <SocialLink key={i} href={href} rel="noreferrer" target="_blank">
-                <Icon />
-              </SocialLink>
-            ))}
-          </SocialLinks>
-        </CopyrightRow>
-      </Wrapper>
-    </Section>
+    <>
+      <VoteTicker />
+
+      <Section>
+        <Wrapper>
+          <BottomRow>
+            <FooterLinks>
+              <LogoWrapper>
+                <StyledLogo />
+              </LogoWrapper>
+              <LinksFlex>
+                <Links>
+                  {middleLinks.map(({ label, href }, i) => (
+                    <Link key={i} href={href} target="_blank" rel="noreferrer">
+                      {label}
+                    </Link>
+                  ))}
+                </Links>
+                <Links>
+                  {rightLinks.map(({ label, href, Logo }, i) => (
+                    <Link key={i} href={href} target="_blank" rel="noreferrer">
+                      {label} {Logo && <Logo style={{ display: "inline-flex", marginLeft: "4px" }} />}
+                    </Link>
+                  ))}
+                </Links>
+              </LinksFlex>
+            </FooterLinks>
+            <FormWrapper>
+              <FormTitle>Receive the latest UMA and OO news, straight to your inbox.</FormTitle>
+              <Form>
+                <Input value={value} onChange={(e) => setValue(e.target.value)} placeholder="jane@doe.com"></Input>
+                <Button onClick={() => null}>Sign up</Button>
+              </Form>
+            </FormWrapper>
+          </BottomRow>
+          <CopyrightRow>
+            <AddressWrapper>
+              <div>© 2022 Risk Labs</div>
+            </AddressWrapper>
+            <SocialLinks>
+              {socialLinks.map(({ href, Icon }, i) => (
+                <SocialLink key={i} href={href} rel="noreferrer" target="_blank">
+                  <Icon />
+                </SocialLink>
+              ))}
+            </SocialLinks>
+          </CopyrightRow>
+        </Wrapper>
+      </Section>
+    </>
   );
 };
 
@@ -173,7 +178,7 @@ const Links = styled.div`
 
 const Link = styled.a`
   color: var(--black);
-  font: var(--text-md-16);
+  font: var(--body-sm);
   text-decoration: none;
 `;
 

--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -12,7 +12,7 @@ const Footer = () => {
   const { value, setValue } = useFooter();
   return (
     <>
-      <VoteTicker />
+      <VoteTicker theme="light" />
 
       <Section>
         <Wrapper>
@@ -128,7 +128,7 @@ const rightLinks = [
 
 const Section = styled.div`
   width: 100%;
-  background: var(--white-50);
+  background: var(--grey-100);
   background-image: url("assets/footer-lines-grey.png");
   background-size: 100% auto;
   background-repeat: no-repeat;

--- a/components/GlobalStyle/GlobalStyle.ts
+++ b/components/GlobalStyle/GlobalStyle.ts
@@ -1,6 +1,8 @@
 import {
   black,
   black100,
+  black150,
+  black150Opacity20,
   blackOpacity25,
   blackOpacity50,
   blackOpacity60,
@@ -13,11 +15,13 @@ import {
   grey900,
   grey910,
   grey950,
+  greyOpacity20,
   loadingSkeletonOpacity10,
   loadingSkeletonOpacity100,
-  red100,
   red500,
   red500Opacity5,
+  red510Opacity15,
+  red550,
   red600,
   white,
   white50,
@@ -199,13 +203,16 @@ a:not([class]) {
     --white-50: ${white50};
     --black: ${black};
     --black-100: ${black100};
+    --black-150: ${black150};
+    --black-150-opacity-20: ${black150Opacity20};
     --black-opacity-25: ${blackOpacity25};
     --black-opacity-50: ${blackOpacity50};
     --black-opacity-60: ${blackOpacity60};
     --black-opacity-75: ${blackOpacity75};
-    --red-100: ${red100};
     --red-500: ${red500};
     --red-500-opacity-5: ${red500Opacity5};
+    --red-510-opacity-15: ${red510Opacity15};
+    --red-550: ${red550};
     --red-600: ${red600};
     --green: ${green};
     --grey-50: ${grey50};
@@ -215,6 +222,7 @@ a:not([class]) {
     --grey-900: ${grey900};
     --grey-910: ${grey910};
     --grey-950: ${grey950};
+    --grey-opacity-20: ${greyOpacity20};
     --loading-skeleton-opacity-100: ${loadingSkeletonOpacity100};
     --loading-skeleton-opacity-10: ${loadingSkeletonOpacity10};
     /* Fonts */

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -4,7 +4,7 @@ import { VoteTicker } from "components";
 const Header = () => {
   return (
     <>
-      <VoteTicker theme="dark" />
+      <VoteTicker theme="dark" numVotes={2} />
       <Wrapper>
         <a href="/">
           <Logo />

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -1,22 +1,25 @@
 import styled from "styled-components";
 import Logo from "public/assets/uma-logo.svg";
-
+import VoteTicker from "components/VoteTicker";
 const Header = () => {
   return (
-    <Wrapper>
-      <a href="/">
-        <Logo />
-      </a>
-      <Links>
-        {/* TODO: Get links */}
-        {links.map(({ label, href }, i) => (
-          <Link key={i} href={href}>
-            {label}
-          </Link>
-        ))}
-        <LaunchButton onClick={() => null}>Launch app</LaunchButton>
-      </Links>
-    </Wrapper>
+    <>
+      <VoteTicker />
+      <Wrapper>
+        <a href="/">
+          <Logo />
+        </a>
+        <Links>
+          {/* TODO: Get links */}
+          {links.map(({ label, href }, i) => (
+            <Link key={i} href={href}>
+              {label}
+            </Link>
+          ))}
+          <LaunchButton onClick={() => null}>Launch app</LaunchButton>
+        </Links>
+      </Wrapper>
+    </>
   );
 };
 
@@ -46,7 +49,7 @@ const Wrapper = styled.div`
   align-items: center;
   height: 40px;
   max-width: var(--max-section-width);
-  padding-top: 68px;
+  padding-top: 100px;
   margin: 0 auto;
 `;
 

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import Logo from "public/assets/uma-logo.svg";
-import VoteTicker from "components/VoteTicker";
+import { VoteTicker } from "components";
 const Header = () => {
   return (
     <>

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -4,7 +4,7 @@ import { VoteTicker } from "components";
 const Header = () => {
   return (
     <>
-      <VoteTicker />
+      <VoteTicker theme="dark" />
       <Wrapper>
         <a href="/">
           <Logo />

--- a/components/VoteTicker/VoteTicker.tsx
+++ b/components/VoteTicker/VoteTicker.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import Clock from "public/assets/clock.svg";
 import UpRightArrow from "public/assets/up-right-arrow.svg";
 import { formatDateTimeFromUTC } from "./utils";
-
+import useInterval from "hooks/helpers/useInterval";
 type theme = "light" | "dark";
 
 interface Props {
@@ -38,19 +38,14 @@ const VoteTicker: React.FC<Props> = ({ theme }) => {
 export default VoteTicker;
 
 function useVoteTicker() {
-  const [timeRemaining, setTimeRemaining] = useState("00:00");
+  const [timeRemaining, setTimeRemaining] = useState("--:--:--");
   // Set time remaining depending if it's the Commit or Reveal
   // Note: the requests are all slightly differently in there final vote time. I'll use the last
   // Vote added.
-  useEffect(() => {
+  useInterval(() => {
     setTimeRemaining(formatDateTimeFromUTC());
+  }, 1000);
 
-    const timer = setInterval(() => {
-      setTimeRemaining(formatDateTimeFromUTC());
-    }, 1000);
-
-    return () => clearInterval(timer);
-  }, []);
   return { timeRemaining };
 }
 

--- a/components/VoteTicker/VoteTicker.tsx
+++ b/components/VoteTicker/VoteTicker.tsx
@@ -10,21 +10,21 @@ interface Props {
   theme: theme;
 }
 
-const VoteTicker: React.FC<Props> = ({ theme = "dark" }) => {
+const VoteTicker: React.FC<Props> = ({ theme }) => {
   const { timeRemaining } = useVoteTicker();
   return (
-    <Section>
-      <Wrapper>
-        <VoteBlock>
-          <ClockBG>
+    <Section theme={theme}>
+      <Wrapper theme={theme}>
+        <VoteBlock theme={theme}>
+          <ClockBG theme={theme}>
             <Clock />
           </ClockBG>
-          <VoteText>
+          <VoteText theme={theme}>
             Time to commit vote:
             <span>{timeRemaining}</span>
           </VoteText>
         </VoteBlock>
-        <MoreDetailsBlock>
+        <MoreDetailsBlock theme={theme}>
           <span>More details</span>
           <a href="https://vote.umaproject.org/" target="_blank" rel="noreferrer">
             <UpRightArrow />
@@ -63,6 +63,7 @@ const Section = styled.div<IStyledProps>`
   background: ${({ theme }) => (theme === "dark" ? "inherit" : "var(--grey-100)")};
   padding-top: ${({ theme }) => (theme === "dark" ? "16px" : "48px")}; ;
 `;
+
 const Wrapper = styled.div<IStyledProps>`
   display: flex;
   flex-direction: row;
@@ -94,33 +95,36 @@ const ClockBG = styled.div<IStyledProps>`
   gap: 8px;
   width: 32px;
   height: 32px;
-  background: rgba(255, 74, 74, 0.15);
-  border-radius: 28px;
+  background: var(--red-510-opacity-15);
+  border-radius: ${({ theme }) => (theme === "dark" ? "16px" : "4px")};
   g {
-    fill: #503236;
+    fill: var(--red-550);
+    fill: ${({ theme }) => (theme === "dark" ? "var(--red-550)" : "var(--red-510-opacity-15)")};
   }
 `;
 
 const VoteText = styled.div<IStyledProps>`
   font: var(--body-sm);
-  color: #b0afb3;
+  color: ${({ theme }) => (theme === "dark" ? "var(--grey-910)" : "var(--black-150)")};
   span {
-    color: var(--white);
+    color: ${({ theme }) => (theme === "dark" ? "var(--white)" : "var(--red-550)")};
+    color: var(--red-500);
     margin-left: 4px;
   }
   padding-right: 16px;
-  border-right: 1px solid hsl(255, 2%, 64%, 0.2);
+  border-right: ${({ theme }) =>
+    theme === "dark" ? "1px solid var(--grey-opacity-20)" : "1px solid var(--black-150-opacity-20)"};
 `;
 
 const MoreDetailsBlock = styled.div<IStyledProps>`
   font: var(--body-sm);
-  color: #b0afb3;
+  color: ${({ theme }) => (theme === "dark" ? "var(--grey-910)" : "var(--black-150)")};
   display: flex;
   flex-direction: row;
   align-items: center;
   padding: 0px;
   gap: 4px;
   path {
-    stroke: #b0afb3;
+    stroke: ${({ theme }) => (theme === "dark" ? "var(--grey-910)" : "var(--black-150)")};
   }
 `;

--- a/components/VoteTicker/VoteTicker.tsx
+++ b/components/VoteTicker/VoteTicker.tsx
@@ -1,0 +1,5 @@
+const VoteTicker = () => {
+  return <div />;
+};
+
+export default VoteTicker;

--- a/components/VoteTicker/VoteTicker.tsx
+++ b/components/VoteTicker/VoteTicker.tsx
@@ -1,6 +1,19 @@
 import styled from "styled-components";
+import Clock from "public/assets/clock.svg";
 const VoteTicker = () => {
-  return <Wrapper></Wrapper>;
+  return (
+    <Wrapper>
+      <VoteBlock>
+        <ClockBG>
+          <Clock />
+        </ClockBG>
+        <VoteText>
+          Time to commit vote:
+          <span>7h 32m 21s</span>
+        </VoteText>
+      </VoteBlock>
+    </Wrapper>
+  );
 };
 
 export default VoteTicker;
@@ -26,4 +39,45 @@ const Wrapper = styled.div`
 
   background: #322f33;
   border-radius: 8px;
+`;
+
+const VoteBlock = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 0px;
+  gap: 16px;
+  /* Inside auto layout */
+
+  flex: none;
+  order: 1;
+  flex-grow: 0;
+  z-index: 1;
+`;
+
+const ClockBG = styled.div`
+  /* Auto layout */
+
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  /* padding: 3px 4px; */
+  gap: 8px;
+
+  width: 32px;
+  height: 32px;
+
+  /* Red-15 */
+
+  background: rgba(255, 74, 74, 0.15);
+  border-radius: 28px;
+`;
+
+const VoteText = styled.div`
+  font: var(--body-sm);
+  color: var(--grey-150);
+  span {
+    color: var(--white);
+  }
 `;

--- a/components/VoteTicker/VoteTicker.tsx
+++ b/components/VoteTicker/VoteTicker.tsx
@@ -1,7 +1,10 @@
+import { useState, useEffect } from "react";
 import styled from "styled-components";
 import Clock from "public/assets/clock.svg";
 import UpRightArrow from "public/assets/up-right-arrow.svg";
+import calculateTimeRemaining from "./calculateTimeRemaining";
 const VoteTicker = () => {
+  const { timeRemaining } = useVoteTicker();
   return (
     <Section>
       <Wrapper>
@@ -11,7 +14,7 @@ const VoteTicker = () => {
           </ClockBG>
           <VoteText>
             Time to commit vote:
-            <span>7h 32m 21s</span>
+            <span>{timeRemaining}</span>
           </VoteText>
         </VoteBlock>
         <MoreDetailsBlock>
@@ -26,6 +29,23 @@ const VoteTicker = () => {
 };
 
 export default VoteTicker;
+
+function useVoteTicker() {
+  const [timeRemaining, setTimeRemaining] = useState("00:00");
+  // Set time remaining depending if it's the Commit or Reveal
+  // Note: the requests are all slightly differently in there final vote time. I'll use the last
+  // Vote added.
+  useEffect(() => {
+    setTimeRemaining(calculateTimeRemaining());
+
+    const timer = setInterval(() => {
+      setTimeRemaining(calculateTimeRemaining());
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, []);
+  return { timeRemaining };
+}
 const Section = styled.div`
   width: 100%;
   background: inherit;

--- a/components/VoteTicker/VoteTicker.tsx
+++ b/components/VoteTicker/VoteTicker.tsx
@@ -14,10 +14,22 @@ interface Props {
 // styled theme
 const st = {
   light: {
-    background: "var(--white-50)",
+    wrapper: {
+      bg: "var(--white-50)",
+    },
+    section: {
+      bg: "var(--grey-100)",
+      pt: "48px",
+    },
   },
   dark: {
-    wrapperBg: "var(--black)",
+    wrapper: {
+      bg: "var(--black)",
+    },
+    section: {
+      bg: "inherit",
+      pt: "16px",
+    },
   },
 };
 
@@ -71,8 +83,8 @@ interface IStyledProps {
 
 const Section = styled.div<IStyledProps>`
   width: 100%;
-  background: ${({ themeType }) => (themeType === "dark" ? "inherit" : "var(--grey-100)")};
-  padding-top: ${({ themeType }) => (themeType === "dark" ? "16px" : "48px")}; ;
+  background: ${({ themeType, theme }) => (themeType === "dark" ? theme.dark.section.bg : theme.light.section.bg)};
+  padding-top: ${({ themeType, theme }) => (themeType === "dark" ? theme.dark.section.pt : theme.light.section.pt)}; ;
 `;
 
 const Wrapper = styled.div<IStyledProps>`

--- a/components/VoteTicker/VoteTicker.tsx
+++ b/components/VoteTicker/VoteTicker.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import styled from "styled-components";
 import Clock from "public/assets/clock.svg";
 import UpRightArrow from "public/assets/up-right-arrow.svg";
-import calculateTimeRemaining from "./calculateTimeRemaining";
+import { formatDateTimeFromUTC } from "./utils";
 
 type theme = "light" | "dark";
 
@@ -43,10 +43,10 @@ function useVoteTicker() {
   // Note: the requests are all slightly differently in there final vote time. I'll use the last
   // Vote added.
   useEffect(() => {
-    setTimeRemaining(calculateTimeRemaining());
+    setTimeRemaining(formatDateTimeFromUTC());
 
     const timer = setInterval(() => {
-      setTimeRemaining(calculateTimeRemaining());
+      setTimeRemaining(formatDateTimeFromUTC());
     }, 1000);
 
     return () => clearInterval(timer);

--- a/components/VoteTicker/VoteTicker.tsx
+++ b/components/VoteTicker/VoteTicker.tsx
@@ -4,11 +4,13 @@ import Clock from "public/assets/clock.svg";
 import UpRightArrow from "public/assets/up-right-arrow.svg";
 import calculateTimeRemaining from "./calculateTimeRemaining";
 
+type theme = "light" | "dark";
+
 interface Props {
-  theme: "light" | "dark";
+  theme: theme;
 }
 
-const VoteTicker = ({ theme = "dark" }) => {
+const VoteTicker: React.FC<Props> = ({ theme = "dark" }) => {
   const { timeRemaining } = useVoteTicker();
   return (
     <Section>
@@ -53,13 +55,13 @@ function useVoteTicker() {
 }
 
 interface IStyledProps {
-  theme: "light" | "dark";
+  theme: theme;
 }
 
 const Section = styled.div<IStyledProps>`
   width: 100%;
-  background: inherit;
-  padding-top: 16px;
+  background: ${({ theme }) => (theme === "dark" ? "inherit" : "var(--grey-100)")};
+  padding-top: ${({ theme }) => (theme === "dark" ? "16px" : "48px")}; ;
 `;
 const Wrapper = styled.div<IStyledProps>`
   display: flex;
@@ -72,7 +74,7 @@ const Wrapper = styled.div<IStyledProps>`
   max-width: var(--max-section-width);
   margin: 0 auto;
   height: 48px;
-  background: #322f33;
+  background: ${({ theme }) => (theme === "dark" ? "var(--black-100)" : "var(--white-50)")};
   border-radius: 8px;
 `;
 

--- a/components/VoteTicker/VoteTicker.tsx
+++ b/components/VoteTicker/VoteTicker.tsx
@@ -25,6 +25,19 @@ const styledTheme = {
       br: "4px",
       fill: "var(--red-510-opacity-15)",
     },
+    voteText: {
+      color: "var(--black-150)",
+      spanColor: "var(--red-500)",
+      borderRight: "1px solid var(--black-150-opacity-20)",
+    },
+    numVotes: {
+      bg: "var(--grey-150)",
+      color: "var(--black-150)",
+    },
+    moreDetails: {
+      color: "var(--black-150)",
+      stroke: "var(--black-150)",
+    },
   },
   dark: {
     section: {
@@ -38,6 +51,20 @@ const styledTheme = {
       br: "16px",
       fill: "var(--red-550)",
     },
+    voteText: {
+      color: "var(--grey-910)",
+      spanColor: "var(--white)",
+      borderRight: "1px solid var(--grey-opacity-20)",
+    },
+    numVotes: {
+      color: "var(--grey-910)",
+      bg: "var(--black-150)",
+    },
+    moreDetails: {
+      color: "var(--grey-910)",
+
+      stroke: "var(--grey-910)",
+    },
   },
 };
 
@@ -48,18 +75,18 @@ const VoteTicker: React.FC<Props> = ({ theme, numVotes }) => {
       <Section>
         <Wrapper>
           <VoteBlock>
-            <ClockBG themeType={theme}>
+            <ClockBG>
               <Clock />
             </ClockBG>
-            <VoteText themeType={theme}>
+            <VoteText>
               Time to commit vote:
               <span>{timeRemaining}</span>
             </VoteText>
-            <NumVotes themeType={theme}>
+            <NumVotes>
               <div>{numVotes === 1 ? "1 vote" : `${numVotes} votes`}</div>{" "}
             </NumVotes>
           </VoteBlock>
-          <MoreDetailsBlock themeType={theme}>
+          <MoreDetailsBlock>
             <span>More details</span>
             <a href="https://vote.umaproject.org/" target="_blank" rel="noreferrer">
               <UpRightArrow />
@@ -83,10 +110,6 @@ function useVoteTicker() {
   }, 1000);
 
   return { timeRemaining };
-}
-
-interface IStyledProps {
-  themeType: TickerThemes;
 }
 
 const Section = styled.div`
@@ -133,20 +156,18 @@ const ClockBG = styled.div`
   }
 `;
 
-const VoteText = styled.div<IStyledProps>`
+const VoteText = styled.div`
   font: var(--body-sm);
-  color: ${({ themeType }) => (themeType === "dark" ? "var(--grey-910)" : "var(--black-150)")};
+  color: ${({ theme }) => theme.voteText.color};
   span {
-    color: ${({ themeType }) => (themeType === "dark" ? "var(--white)" : "var(--red-550)")};
-    color: var(--red-500);
+    color: ${({ theme }) => theme.voteText.spanColor};
     margin-left: 4px;
   }
   padding-right: 16px;
-  border-right: ${({ themeType }) =>
-    themeType === "dark" ? "1px solid var(--grey-opacity-20)" : "1px solid var(--black-150-opacity-20)"};
+  border-right: ${({ theme }) => theme.voteText.borderRight};
 `;
 
-const NumVotes = styled.div<IStyledProps>`
+const NumVotes = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: center;
@@ -155,23 +176,23 @@ const NumVotes = styled.div<IStyledProps>`
   gap: 2px;
   width: 63px;
   height: 24px;
-  background: var(--grey-150);
+  background: ${({ theme }) => theme.numVotes.bg};
   border-radius: 12px;
   > div {
     font: var(--body-sm);
-    color: var(--black-150);
+    color: ${({ theme }) => theme.numVotes.color};
   }
 `;
 
-const MoreDetailsBlock = styled.div<IStyledProps>`
+const MoreDetailsBlock = styled.div`
   font: var(--body-sm);
-  color: ${({ themeType }) => (themeType === "dark" ? "var(--grey-910)" : "var(--black-150)")};
+  color: ${({ theme }) => theme.moreDetails.color};
   display: flex;
   flex-direction: row;
   align-items: center;
   padding: 0px;
   gap: 4px;
   path {
-    stroke: ${({ themeType }) => (themeType === "dark" ? "var(--grey-910)" : "var(--black-150)")};
+    stroke: ${({ theme }) => theme.moreDetails.stroke};
   }
 `;

--- a/components/VoteTicker/VoteTicker.tsx
+++ b/components/VoteTicker/VoteTicker.tsx
@@ -8,6 +8,7 @@ type TickerThemes = "light" | "dark";
 
 interface Props {
   theme: TickerThemes;
+  numVotes: number;
 }
 
 // styled theme
@@ -20,7 +21,7 @@ const st = {
   },
 };
 
-const VoteTicker: React.FC<Props> = ({ theme }) => {
+const VoteTicker: React.FC<Props> = ({ theme, numVotes }) => {
   const { timeRemaining } = useVoteTicker();
   return (
     <ThemeProvider theme={st}>
@@ -34,6 +35,9 @@ const VoteTicker: React.FC<Props> = ({ theme }) => {
               Time to commit vote:
               <span>{timeRemaining}</span>
             </VoteText>
+            <NumVotes themeType={theme}>
+              <div>{numVotes === 1 ? "1 vote" : `${numVotes} votes`}</div>{" "}
+            </NumVotes>
           </VoteBlock>
           <MoreDetailsBlock themeType={theme}>
             <span>More details</span>
@@ -121,6 +125,23 @@ const VoteText = styled.div<IStyledProps>`
   padding-right: 16px;
   border-right: ${({ themeType }) =>
     themeType === "dark" ? "1px solid var(--grey-opacity-20)" : "1px solid var(--black-150-opacity-20)"};
+`;
+
+const NumVotes = styled.div<IStyledProps>`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  padding: 8px 8px 12px;
+  gap: 2px;
+  width: 63px;
+  height: 24px;
+  background: var(--grey-150);
+  border-radius: 12px;
+  > div {
+    font: var(--body-sm);
+    color: var(--black-150);
+  }
 `;
 
 const MoreDetailsBlock = styled.div<IStyledProps>`

--- a/components/VoteTicker/VoteTicker.tsx
+++ b/components/VoteTicker/VoteTicker.tsx
@@ -3,7 +3,12 @@ import styled from "styled-components";
 import Clock from "public/assets/clock.svg";
 import UpRightArrow from "public/assets/up-right-arrow.svg";
 import calculateTimeRemaining from "./calculateTimeRemaining";
-const VoteTicker = () => {
+
+interface Props {
+  theme: "light" | "dark";
+}
+
+const VoteTicker = ({ theme = "dark" }) => {
   const { timeRemaining } = useVoteTicker();
   return (
     <Section>
@@ -46,14 +51,17 @@ function useVoteTicker() {
   }, []);
   return { timeRemaining };
 }
-const Section = styled.div`
+
+interface IStyledProps {
+  theme: "light" | "dark";
+}
+
+const Section = styled.div<IStyledProps>`
   width: 100%;
   background: inherit;
   padding-top: 16px;
 `;
-const Wrapper = styled.div`
-  /* Auto layout */
-
+const Wrapper = styled.div<IStyledProps>`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -61,13 +69,9 @@ const Wrapper = styled.div`
   padding: 8px 16px 8px 8px;
   gap: 16px;
   isolation: isolate;
-
   max-width: var(--max-section-width);
   margin: 0 auto;
   height: 48px;
-
-  /* Gray/Gray-200 */
-
   background: #322f33;
   border-radius: 8px;
 `;
@@ -78,29 +82,16 @@ const VoteBlock = styled.div`
   align-items: center;
   padding: 0px;
   gap: 16px;
-  /* Inside auto layout */
-
-  /* flex: none;
-  order: 1;
-  flex-grow: 0;
-  z-index: 1; */
 `;
 
-const ClockBG = styled.div`
-  /* Auto layout */
-
+const ClockBG = styled.div<IStyledProps>`
   display: flex;
   flex-direction: row;
   justify-content: center;
   align-items: center;
-  /* padding: 3px 4px; */
   gap: 8px;
-
   width: 32px;
   height: 32px;
-
-  /* Red-15 */
-
   background: rgba(255, 74, 74, 0.15);
   border-radius: 28px;
   g {
@@ -108,7 +99,7 @@ const ClockBG = styled.div`
   }
 `;
 
-const VoteText = styled.div`
+const VoteText = styled.div<IStyledProps>`
   font: var(--body-sm);
   color: #b0afb3;
   span {
@@ -119,7 +110,7 @@ const VoteText = styled.div`
   border-right: 1px solid hsl(255, 2%, 64%, 0.2);
 `;
 
-const MoreDetailsBlock = styled.div`
+const MoreDetailsBlock = styled.div<IStyledProps>`
   font: var(--body-sm);
   color: #b0afb3;
   display: flex;

--- a/components/VoteTicker/VoteTicker.tsx
+++ b/components/VoteTicker/VoteTicker.tsx
@@ -1,23 +1,36 @@
 import styled from "styled-components";
 import Clock from "public/assets/clock.svg";
+import UpRightArrow from "public/assets/up-right-arrow.svg";
 const VoteTicker = () => {
   return (
-    <Wrapper>
-      <VoteBlock>
-        <ClockBG>
-          <Clock />
-        </ClockBG>
-        <VoteText>
-          Time to commit vote:
-          <span>7h 32m 21s</span>
-        </VoteText>
-      </VoteBlock>
-    </Wrapper>
+    <Section>
+      <Wrapper>
+        <VoteBlock>
+          <ClockBG>
+            <Clock />
+          </ClockBG>
+          <VoteText>
+            Time to commit vote:
+            <span>7h 32m 21s</span>
+          </VoteText>
+        </VoteBlock>
+        <MoreDetailsBlock>
+          <span>More details</span>
+          <a href="https://vote.umaproject.org/" target="_blank" rel="noreferrer">
+            <UpRightArrow />
+          </a>
+        </MoreDetailsBlock>
+      </Wrapper>
+    </Section>
   );
 };
 
 export default VoteTicker;
-
+const Section = styled.div`
+  width: 100%;
+  background: inherit;
+  padding-top: 16px;
+`;
 const Wrapper = styled.div`
   /* Auto layout */
 
@@ -29,11 +42,9 @@ const Wrapper = styled.div`
   gap: 16px;
   isolation: isolate;
 
-  position: absolute;
-  width: 1144px;
+  max-width: var(--max-section-width);
+  margin: 0 auto;
   height: 48px;
-  left: 148px;
-  top: 16px;
 
   /* Gray/Gray-200 */
 
@@ -49,10 +60,10 @@ const VoteBlock = styled.div`
   gap: 16px;
   /* Inside auto layout */
 
-  flex: none;
+  /* flex: none;
   order: 1;
   flex-grow: 0;
-  z-index: 1;
+  z-index: 1; */
 `;
 
 const ClockBG = styled.div`
@@ -72,12 +83,31 @@ const ClockBG = styled.div`
 
   background: rgba(255, 74, 74, 0.15);
   border-radius: 28px;
+  g {
+    fill: #503236;
+  }
 `;
 
 const VoteText = styled.div`
   font: var(--body-sm);
-  color: var(--grey-150);
+  color: #b0afb3;
   span {
     color: var(--white);
+    margin-left: 4px;
+  }
+  padding-right: 16px;
+  border-right: 1px solid hsl(255, 2%, 64%, 0.2);
+`;
+
+const MoreDetailsBlock = styled.div`
+  font: var(--body-sm);
+  color: #b0afb3;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 0px;
+  gap: 4px;
+  path {
+    stroke: #b0afb3;
   }
 `;

--- a/components/VoteTicker/VoteTicker.tsx
+++ b/components/VoteTicker/VoteTicker.tsx
@@ -12,23 +12,31 @@ interface Props {
 }
 
 // styled theme
-const st = {
+const styledTheme = {
   light: {
-    wrapper: {
-      bg: "var(--white-50)",
-    },
     section: {
       bg: "var(--grey-100)",
       pt: "48px",
     },
+    wrapper: {
+      bg: "var(--white-50)",
+    },
+    clock: {
+      br: "4px",
+      fill: "var(--red-510-opacity-15)",
+    },
   },
   dark: {
-    wrapper: {
-      bg: "var(--black)",
-    },
     section: {
       bg: "inherit",
       pt: "16px",
+    },
+    wrapper: {
+      bg: "var(--black-100)",
+    },
+    clock: {
+      br: "16px",
+      fill: "var(--red-550)",
     },
   },
 };
@@ -36,9 +44,9 @@ const st = {
 const VoteTicker: React.FC<Props> = ({ theme, numVotes }) => {
   const { timeRemaining } = useVoteTicker();
   return (
-    <ThemeProvider theme={st}>
-      <Section themeType={theme}>
-        <Wrapper themeType={theme}>
+    <ThemeProvider theme={styledTheme[theme]}>
+      <Section>
+        <Wrapper>
           <VoteBlock>
             <ClockBG themeType={theme}>
               <Clock />
@@ -81,13 +89,13 @@ interface IStyledProps {
   themeType: TickerThemes;
 }
 
-const Section = styled.div<IStyledProps>`
+const Section = styled.div`
   width: 100%;
-  background: ${({ themeType, theme }) => (themeType === "dark" ? theme.dark.section.bg : theme.light.section.bg)};
-  padding-top: ${({ themeType, theme }) => (themeType === "dark" ? theme.dark.section.pt : theme.light.section.pt)}; ;
+  background: ${({ theme }) => theme.section.bg};
+  padding-top: ${({ theme }) => theme.section.pt}; ;
 `;
 
-const Wrapper = styled.div<IStyledProps>`
+const Wrapper = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -98,7 +106,7 @@ const Wrapper = styled.div<IStyledProps>`
   max-width: var(--max-section-width);
   margin: 0 auto;
   height: 48px;
-  background: ${({ themeType }) => (themeType === "dark" ? "var(--black-100)" : "var(--white-50)")};
+  background: ${({ theme }) => theme.wrapper.bg};
   border-radius: 8px;
 `;
 
@@ -110,7 +118,7 @@ const VoteBlock = styled.div`
   gap: 16px;
 `;
 
-const ClockBG = styled.div<IStyledProps>`
+const ClockBG = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: center;
@@ -119,10 +127,9 @@ const ClockBG = styled.div<IStyledProps>`
   width: 32px;
   height: 32px;
   background: var(--red-510-opacity-15);
-  border-radius: ${({ themeType }) => (themeType === "dark" ? "16px" : "4px")};
+  border-radius: ${({ theme }) => theme.clock.br};
   g {
-    fill: var(--red-550);
-    fill: ${({ themeType }) => (themeType === "dark" ? "var(--red-550)" : "var(--red-510-opacity-15)")};
+    fill: ${({ theme }) => theme.clock.fill};
   }
 `;
 

--- a/components/VoteTicker/VoteTicker.tsx
+++ b/components/VoteTicker/VoteTicker.tsx
@@ -1,37 +1,49 @@
-import { useState, useEffect } from "react";
-import styled from "styled-components";
+import { useState } from "react";
+import styled, { ThemeProvider } from "styled-components";
 import Clock from "public/assets/clock.svg";
 import UpRightArrow from "public/assets/up-right-arrow.svg";
 import { formatDateTimeFromUTC } from "./utils";
 import useInterval from "hooks/helpers/useInterval";
-type theme = "light" | "dark";
+type TickerThemes = "light" | "dark";
 
 interface Props {
-  theme: theme;
+  theme: TickerThemes;
 }
+
+// styled theme
+const st = {
+  light: {
+    background: "var(--white-50)",
+  },
+  dark: {
+    wrapperBg: "var(--black)",
+  },
+};
 
 const VoteTicker: React.FC<Props> = ({ theme }) => {
   const { timeRemaining } = useVoteTicker();
   return (
-    <Section theme={theme}>
-      <Wrapper theme={theme}>
-        <VoteBlock theme={theme}>
-          <ClockBG theme={theme}>
-            <Clock />
-          </ClockBG>
-          <VoteText theme={theme}>
-            Time to commit vote:
-            <span>{timeRemaining}</span>
-          </VoteText>
-        </VoteBlock>
-        <MoreDetailsBlock theme={theme}>
-          <span>More details</span>
-          <a href="https://vote.umaproject.org/" target="_blank" rel="noreferrer">
-            <UpRightArrow />
-          </a>
-        </MoreDetailsBlock>
-      </Wrapper>
-    </Section>
+    <ThemeProvider theme={st}>
+      <Section themeType={theme}>
+        <Wrapper themeType={theme}>
+          <VoteBlock>
+            <ClockBG themeType={theme}>
+              <Clock />
+            </ClockBG>
+            <VoteText themeType={theme}>
+              Time to commit vote:
+              <span>{timeRemaining}</span>
+            </VoteText>
+          </VoteBlock>
+          <MoreDetailsBlock themeType={theme}>
+            <span>More details</span>
+            <a href="https://vote.umaproject.org/" target="_blank" rel="noreferrer">
+              <UpRightArrow />
+            </a>
+          </MoreDetailsBlock>
+        </Wrapper>
+      </Section>
+    </ThemeProvider>
   );
 };
 
@@ -50,13 +62,13 @@ function useVoteTicker() {
 }
 
 interface IStyledProps {
-  theme: theme;
+  themeType: TickerThemes;
 }
 
 const Section = styled.div<IStyledProps>`
   width: 100%;
-  background: ${({ theme }) => (theme === "dark" ? "inherit" : "var(--grey-100)")};
-  padding-top: ${({ theme }) => (theme === "dark" ? "16px" : "48px")}; ;
+  background: ${({ themeType }) => (themeType === "dark" ? "inherit" : "var(--grey-100)")};
+  padding-top: ${({ themeType }) => (themeType === "dark" ? "16px" : "48px")}; ;
 `;
 
 const Wrapper = styled.div<IStyledProps>`
@@ -70,7 +82,7 @@ const Wrapper = styled.div<IStyledProps>`
   max-width: var(--max-section-width);
   margin: 0 auto;
   height: 48px;
-  background: ${({ theme }) => (theme === "dark" ? "var(--black-100)" : "var(--white-50)")};
+  background: ${({ themeType }) => (themeType === "dark" ? "var(--black-100)" : "var(--white-50)")};
   border-radius: 8px;
 `;
 
@@ -91,35 +103,35 @@ const ClockBG = styled.div<IStyledProps>`
   width: 32px;
   height: 32px;
   background: var(--red-510-opacity-15);
-  border-radius: ${({ theme }) => (theme === "dark" ? "16px" : "4px")};
+  border-radius: ${({ themeType }) => (themeType === "dark" ? "16px" : "4px")};
   g {
     fill: var(--red-550);
-    fill: ${({ theme }) => (theme === "dark" ? "var(--red-550)" : "var(--red-510-opacity-15)")};
+    fill: ${({ themeType }) => (themeType === "dark" ? "var(--red-550)" : "var(--red-510-opacity-15)")};
   }
 `;
 
 const VoteText = styled.div<IStyledProps>`
   font: var(--body-sm);
-  color: ${({ theme }) => (theme === "dark" ? "var(--grey-910)" : "var(--black-150)")};
+  color: ${({ themeType }) => (themeType === "dark" ? "var(--grey-910)" : "var(--black-150)")};
   span {
-    color: ${({ theme }) => (theme === "dark" ? "var(--white)" : "var(--red-550)")};
+    color: ${({ themeType }) => (themeType === "dark" ? "var(--white)" : "var(--red-550)")};
     color: var(--red-500);
     margin-left: 4px;
   }
   padding-right: 16px;
-  border-right: ${({ theme }) =>
-    theme === "dark" ? "1px solid var(--grey-opacity-20)" : "1px solid var(--black-150-opacity-20)"};
+  border-right: ${({ themeType }) =>
+    themeType === "dark" ? "1px solid var(--grey-opacity-20)" : "1px solid var(--black-150-opacity-20)"};
 `;
 
 const MoreDetailsBlock = styled.div<IStyledProps>`
   font: var(--body-sm);
-  color: ${({ theme }) => (theme === "dark" ? "var(--grey-910)" : "var(--black-150)")};
+  color: ${({ themeType }) => (themeType === "dark" ? "var(--grey-910)" : "var(--black-150)")};
   display: flex;
   flex-direction: row;
   align-items: center;
   padding: 0px;
   gap: 4px;
   path {
-    stroke: ${({ theme }) => (theme === "dark" ? "var(--grey-910)" : "var(--black-150)")};
+    stroke: ${({ themeType }) => (themeType === "dark" ? "var(--grey-910)" : "var(--black-150)")};
   }
 `;

--- a/components/VoteTicker/VoteTicker.tsx
+++ b/components/VoteTicker/VoteTicker.tsx
@@ -1,5 +1,29 @@
+import styled from "styled-components";
 const VoteTicker = () => {
-  return <div />;
+  return <Wrapper></Wrapper>;
 };
 
 export default VoteTicker;
+
+const Wrapper = styled.div`
+  /* Auto layout */
+
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 16px 8px 8px;
+  gap: 16px;
+  isolation: isolate;
+
+  position: absolute;
+  width: 1144px;
+  height: 48px;
+  left: 148px;
+  top: 16px;
+
+  /* Gray/Gray-200 */
+
+  background: #322f33;
+  border-radius: 8px;
+`;

--- a/components/VoteTicker/calculateTimeRemaining.ts
+++ b/components/VoteTicker/calculateTimeRemaining.ts
@@ -1,0 +1,14 @@
+import { DateTime, Duration } from "luxon";
+
+// For Timer feature.
+// Countdown from UTC 00:00:00.
+export default function calculateTimeRemaining() {
+  const utc = DateTime.local().toUTC().endOf("day").toMillis();
+  const difference = utc - DateTime.local().toMillis();
+
+  let text = "00:00";
+  // format difference
+  if (difference > 0) text = Duration.fromMillis(difference).toFormat("hh'h' mm'm' ss's'");
+
+  return text;
+}

--- a/components/VoteTicker/index.ts
+++ b/components/VoteTicker/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./VoteTicker";

--- a/components/VoteTicker/utils.ts
+++ b/components/VoteTicker/utils.ts
@@ -2,9 +2,15 @@ import { DateTime, Duration } from "luxon";
 
 // For Timer feature.
 // Countdown from UTC 00:00:00.
-export default function calculateTimeRemaining() {
+
+export function calculateDifferenceFromUTCMidnight() {
   const utc = DateTime.local().toUTC().endOf("day").toMillis();
   const difference = utc - DateTime.local().toMillis();
+
+  return difference;
+}
+export function formatDateTimeFromUTC() {
+  const difference = calculateDifferenceFromUTCMidnight();
 
   let text = "00:00";
   // format difference

--- a/components/index.ts
+++ b/components/index.ts
@@ -10,3 +10,4 @@ export { default as Projects } from "./Projects";
 export { default as Builder } from "./Builder";
 export { default as Tabs } from "./Tabs";
 export { default as SupportSection } from "./SupportSection";
+export { default as VoteTicker } from "./VoteTicker";

--- a/constants/colors.ts
+++ b/constants/colors.ts
@@ -7,6 +7,7 @@ export const white = "hsla(0, 0%, 100%, 1)";
 export const white50 = "hsla(0, 0%, 98%, 1)";
 export const whiteOpacity10 = "hsla(0, 0%, 100%, 0.1)";
 export const black = "hsla(280, 4%, 15%, 1)";
+// #322f33
 export const black100 = "	hsla(285, 4%, 19%, 1)";
 export const blackOpacity25 = "hsla(280, 4%, 15%, 0.25)";
 export const blackOpacity50 = "hsla(280, 4%, 15%, 0.5)";

--- a/constants/colors.ts
+++ b/constants/colors.ts
@@ -1,6 +1,7 @@
-export const red100 = "hsla(0, 100%, 96%, 1)";
 export const red500 = "hsla(0, 100%, 65%, 1)";
 export const red500Opacity5 = "hsla(0, 100%, 65%, 0.05)";
+export const red510Opacity15 = "rgba(255, 74, 74, 0.15)";
+export const red550 = "hsla(352, 23%, 25%, 1)";
 export const red600 = "hsla(360, 79%, 59%, 1)";
 export const green = "hsla(133, 68%, 39%, 1)";
 export const white = "hsla(0, 0%, 100%, 1)";
@@ -9,6 +10,9 @@ export const whiteOpacity10 = "hsla(0, 0%, 100%, 0.1)";
 export const black = "hsla(280, 4%, 15%, 1)";
 // #322f33
 export const black100 = "	hsla(285, 4%, 19%, 1)";
+// #413D42
+export const black150 = "hsla(288, 4%, 25%, 1)";
+export const black150Opacity20 = "hsla(288, 4%, 25%, 0.2)";
 export const blackOpacity25 = "hsla(280, 4%, 15%, 0.25)";
 export const blackOpacity50 = "hsla(280, 4%, 15%, 0.5)";
 export const blackOpacity60 = "hsla(280, 4%, 15%, 0.6)";
@@ -18,6 +22,8 @@ export const grey100 = "hsla(0, 0%, 94%, 1)";
 export const grey150 = "hsla(0, 0%, 92%, 1)";
 export const grey500 = "hsla(0, 0, 84%, 1)";
 export const grey900 = "hsla(255, 3%, 69%, 1)";
+export const greyOpacity20 = "hsla(255, 2%, 64%, 0.2)";
+
 // #B0AFB3
 export const grey910 = "hsla(260, 2%, 69%, 1)";
 export const grey950 = "hsla(300, 1%, 79%, 1)";

--- a/hooks/helpers/useInterval.ts
+++ b/hooks/helpers/useInterval.ts
@@ -1,0 +1,27 @@
+import { useEffect, useRef } from "react";
+
+import useIsomorphicLayoutEffect from "./useIsomorphicLayoutEffect";
+
+function useInterval(callback: () => void, delay: number | null) {
+  const savedCallback = useRef(callback);
+
+  // Remember the latest callback if it changes.
+  useIsomorphicLayoutEffect(() => {
+    savedCallback.current = callback;
+  }, [callback]);
+
+  // Set up the interval.
+  useEffect(() => {
+    // Don't schedule if no delay is specified.
+    // Note: 0 is a valid value for delay.
+    if (!delay && delay !== 0) {
+      return;
+    }
+
+    const id = setInterval(() => savedCallback.current(), delay);
+
+    return () => clearInterval(id);
+  }, [delay]);
+}
+
+export default useInterval;

--- a/hooks/helpers/useIsomorphicLayoutEffect.ts
+++ b/hooks/helpers/useIsomorphicLayoutEffect.ts
@@ -1,0 +1,5 @@
+import { useEffect, useLayoutEffect } from "react";
+
+const useIsomorphicLayoutEffect = typeof window !== "undefined" ? useLayoutEffect : useEffect;
+
+export default useIsomorphicLayoutEffect;

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@storybook/react": "^6.5.12",
     "@storybook/testing-library": "^0.0.13",
     "@svgr/webpack": "^6.3.1",
+    "@types/luxon": "^3.0.2",
     "@types/node": "18.7.23",
     "@types/react": "18.0.21",
     "@types/react-dom": "18.0.6",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@reach/tabs": "^0.18.0",
     "@tanstack/react-query": "^4.7.2",
     "@tanstack/react-query-devtools": "^4.7.2",
+    "luxon": "^3.0.4",
     "next": "12.3.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/public/assets/clock.svg
+++ b/public/assets/clock.svg
@@ -1,0 +1,11 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_406_3757)">
+<path d="M7.99967 14.6668C11.6816 14.6668 14.6663 11.6821 14.6663 8.00016C14.6663 4.31826 11.6816 1.3335 7.99967 1.3335C4.31778 1.3335 1.33301 4.31826 1.33301 8.00016C1.33301 11.6821 4.31778 14.6668 7.99967 14.6668Z" stroke="#FF4A4A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8 4V8L10.6667 9.33333" stroke="#FF4A4A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_406_3757">
+<rect width="16" height="16" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/stories/VoteTicker.stories.tsx
+++ b/stories/VoteTicker.stories.tsx
@@ -1,0 +1,23 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { VoteTicker } from "components";
+
+export default {
+  title: "VoteTicker",
+  component: VoteTicker,
+} as ComponentMeta<typeof VoteTicker>;
+
+const Template: ComponentStory<typeof VoteTicker> = (args) => (
+  <div style={{ padding: "2rem", background: `${args.theme === "light" ? "var(--grey-100)" : "var(--black)"}` }}>
+    <VoteTicker {...args} />
+  </div>
+);
+
+export const Light = Template.bind({});
+Light.args = {
+  theme: "light",
+};
+
+export const Dark = Template.bind({});
+Dark.args = {
+  theme: "dark",
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3114,6 +3114,11 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.186.tgz#862e5514dd7bd66ada6c70ee5fce844b06c8ee97"
   integrity sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw==
 
+"@types/luxon@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-3.0.2.tgz#11361eb3c8a81e9b8d6b35b6ffe155e8eb95480d"
+  integrity sha512-HM2OVWckUMmXbWYZufmWT2XMURGDZ6XbyNyQ+Lx+gCFGFqbZaIjsz7b+AGeGP/AuVYHBiuGY+wXfweP1RremnA==
+
 "@types/mdast@^3.0.0":
   version "3.0.10"
   resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-3.0.10.tgz#4724244a82a4598884cbbe9bcfd73dff927ee8af"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7999,6 +7999,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+luxon@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.0.4.tgz#d179e4e9f05e092241e7044f64aaa54796b03929"
+  integrity sha512-aV48rGUwP/Vydn8HT+5cdr26YYQiUZ42NM6ToMoaGKwYfWbfLeRkEu1wXWMHBZT6+KyLfcbbtVcoQFCbbPjKlw==
+
 lz-string@^1.4.4:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"


### PR DESCRIPTION
1. Vote Ticker widget
<img width="1216" alt="Screen Shot 2022-10-20 at 3 56 10 PM" src="https://user-images.githubusercontent.com/12792146/197074392-573d0f94-b257-4ea5-9615-979e2bfbaca4.png">
<img width="1274" alt="Screen Shot 2022-10-20 at 3 56 14 PM" src="https://user-images.githubusercontent.com/12792146/197074394-41bbf326-fede-4a3e-a533-48ddc41a7b09.png">


2. Some Footer styles / fixes.