### PR TITLE
feat: fixed to tabs to bottom

### DIFF
--- a/components/Builder/Builder.tsx
+++ b/components/Builder/Builder.tsx
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import styled from "styled-components";
 import { Title, Wrapper as DefaultWrapper, Header as BaseHeader } from "components/Widgets";
 import { Tabs } from "components";
@@ -8,13 +9,18 @@ import MedalIcon from "public/assets/medal.svg";
 import CreditCardsIcon from "public/assets/credit-cards.svg";
 import GlobeIcon from "public/assets/globe.svg";
 import { QUERIES, BREAKPOINTS } from "constants/breakpoints";
-import { useWindowSize } from "hooks";
+import { useWindowSize, useIntersectionObserver } from "hooks";
 import Image from "next/image";
 
 const Builder = () => {
+  const sectionRef = useRef<HTMLDivElement | null>(null);
   const { width } = useBuilder();
+  const eSection = useIntersectionObserver(sectionRef, {
+    threshold: 0.6,
+  });
+  const isIntersectingSection = !!eSection?.isIntersecting;
   return (
-    <Section>
+    <Section ref={sectionRef}>
       <Wrapper>
         <Title>
           Participate as a <span>Builder</span>
@@ -40,6 +46,7 @@ const Builder = () => {
           </MobileHeader>
         )}
         <Tabs
+          isIntersecting={isIntersectingSection}
           tabs={[
             {
               title: "Prediction markets",

--- a/components/Builder/Builder.tsx
+++ b/components/Builder/Builder.tsx
@@ -16,7 +16,7 @@ const Builder = () => {
   const sectionRef = useRef<HTMLDivElement | null>(null);
   const { width } = useBuilder();
   const eSection = useIntersectionObserver(sectionRef, {
-    threshold: 0.6,
+    threshold: 0.5,
   });
   const isIntersectingSection = !!eSection?.isIntersecting;
   return (

--- a/components/Tabs/Tabs.tsx
+++ b/components/Tabs/Tabs.tsx
@@ -80,9 +80,10 @@ const TabList = styled(ReachTabList)<ITabList>`
       }
     }
     z-index: 10000;
-    bottom: 6px;
+    bottom: 0px;
     background: #ffffff;
     padding-top: 16px;
+    /* padding-bottom: 6px; */
     position: ${(props) => (props.isIntersecting ? "fixed" : "relative")};
     display: ${(props) => (props.isIntersecting ? "inline-flex !important" : "none !important")};
   }

--- a/components/Tabs/Tabs.tsx
+++ b/components/Tabs/Tabs.tsx
@@ -65,7 +65,7 @@ const TabList = styled(ReachTabList)<ITabList>`
   }
   @media ${QUERIES.tb.andDown} {
     width: 1024px;
-    height: 100px;
+    height: 110px;
     white-space: nowrap;
     -webkit-flex-wrap: nowrap;
     -ms-flex-wrap: nowrap;

--- a/components/Tabs/Tabs.tsx
+++ b/components/Tabs/Tabs.tsx
@@ -84,7 +84,7 @@ const TabList = styled(ReachTabList)<ITabList>`
     background: #ffffff;
     padding-top: 16px;
     position: ${(props) => (props.isIntersecting ? "fixed" : "relative")};
-    display: ${(props) => (props.isIntersecting ? "inline-flex !important" : "none !important")};
+    display: ${(props) => (props.isIntersecting ? "inline-flex" : "none")} !important;
   }
 `;
 

--- a/components/Tabs/Tabs.tsx
+++ b/components/Tabs/Tabs.tsx
@@ -17,12 +17,13 @@ type Tab = {
 
 interface Props {
   tabs: Tab[];
+  isIntersecting?: boolean;
 }
 
-const Tabs = ({ tabs }: Props) => {
+const Tabs = ({ tabs, isIntersecting }: Props) => {
   return (
     <TabsWrapper>
-      <TabList>
+      <TabList isIntersecting={isIntersecting}>
         {tabs.map(({ title, Icon }) => {
           return (
             <Tab key={title}>
@@ -42,7 +43,11 @@ const Tabs = ({ tabs }: Props) => {
 };
 const TabsWrapper = styled(ReachTabs)``;
 
-const TabList = styled(ReachTabList)`
+interface ITabList {
+  isIntersecting?: boolean;
+}
+
+const TabList = styled(ReachTabList)<ITabList>`
   width: 100%;
   height: 68px;
   display: flex;
@@ -62,7 +67,6 @@ const TabList = styled(ReachTabList)`
     width: 1024px;
     height: 100px;
     white-space: nowrap;
-    display: inline-flex !important;
     -webkit-flex-wrap: nowrap;
     -ms-flex-wrap: nowrap;
     flex-wrap: nowrap;
@@ -75,6 +79,12 @@ const TabList = styled(ReachTabList)`
         fill: var(--red);
       }
     }
+    z-index: 10000;
+    bottom: 6px;
+    background: #ffffff;
+    padding-top: 16px;
+    position: ${(props) => (props.isIntersecting ? "fixed" : "relative")};
+    display: ${(props) => (props.isIntersecting ? "inline-flex !important" : "none !important")};
   }
 `;
 

--- a/components/Tabs/Tabs.tsx
+++ b/components/Tabs/Tabs.tsx
@@ -65,7 +65,7 @@ const TabList = styled(ReachTabList)<ITabList>`
   }
   @media ${QUERIES.tb.andDown} {
     width: 1024px;
-    height: 110px;
+    height: 112px;
     white-space: nowrap;
     -webkit-flex-wrap: nowrap;
     -ms-flex-wrap: nowrap;
@@ -83,7 +83,6 @@ const TabList = styled(ReachTabList)<ITabList>`
     bottom: 0px;
     background: #ffffff;
     padding-top: 16px;
-    /* padding-bottom: 6px; */
     position: ${(props) => (props.isIntersecting ? "fixed" : "relative")};
     display: ${(props) => (props.isIntersecting ? "inline-flex !important" : "none !important")};
   }


### PR DESCRIPTION
1. Builder Tabs are fixed to bottom on tablet or less. 
2. Hides / appears based on intersecting section.

<img width="815" alt="Screen Shot 2022-11-04 at 4 04 23 PM" src="https://user-images.githubusercontent.com/12792146/200087055-c36a492b-029e-439f-8e8f-f436effb0ce1.png">

Signed-off-by: Tulun <jaykiraly@gmail.com>
