### PR TITLE
fix: svg hover effect on tabs

### DIFF
--- a/components/Tabs/Tabs.tsx
+++ b/components/Tabs/Tabs.tsx
@@ -67,11 +67,7 @@ const TabList = styled(ReachTabList)<ITabList>`
   transition: all 0.4s ease-in-out;
   position: relative;
   top: 0;
-  svg {
-    transition: all 0.4s ease-in-out;
-  }
   path {
-    transition: all 0.4s ease-in-out;
     fill: var(--grey-900);
   }
   [data-selected] {


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

Previously the svg on the tabs were off color and it wasnt clear they were changing color on hover. now it changes with the text. 

![image](https://user-images.githubusercontent.com/4429761/204538340-2e58f599-23e1-4395-ba99-804b434ec562.png)

Unable to get a screenshot of the hover effect, test it with preview url