### PR TITLE
fix: remove pointer from cursor on tab panel

### DIFF
--- a/components/Tabs/Tabs.tsx
+++ b/components/Tabs/Tabs.tsx
@@ -176,6 +176,7 @@ const TabPanels = styled(ReachTabPanels)`
 `;
 
 const TabPanel = styled(ReachTabPanel)`
+  cursor: default;
   transition: all 0.2 linear;
 `;
 


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

Tab panels looked clickable because cusror changed to pointer. this removes that so it remains an arrow since its not clickable.