### PR TITLE
fix(qa): :lipstick: prevent hero from overflowing its content

### DIFF
--- a/components/Hero/Hero.tsx
+++ b/components/Hero/Hero.tsx
@@ -100,6 +100,7 @@ const OuterWrapper = styled(BaseOuterWrapper)`
   position: relative;
   background: var(--grey-200);
   background-image: url("assets/footer-lines-grey.png");
+  overflow: clip;
 `;
 
 const InnerWrapper = styled.div`


### PR DESCRIPTION
This change prevents the homepage hero animation from overflowing into adjacent sections.

Breaking change: N/A