### PR TITLE
fix(qa): :lipstick: ensure background lines are visible

### DIFF
--- a/components/Hero/Hero.tsx
+++ b/components/Hero/Hero.tsx
@@ -97,9 +97,10 @@ const Background = styled(motion.div)`
 const OuterWrapper = styled(BaseOuterWrapper)`
   padding-top: 0;
   height: calc(100vh - var(--header-height) - var(--vote-ticker-height));
+  width: 100%;
   position: relative;
   background: var(--grey-200);
-  background-image: url("assets/footer-lines-grey.png");
+  background-image: url("assets/hero-bg-lines.svg");
   overflow: clip;
 `;
 

--- a/public/assets/hero-bg-lines.svg
+++ b/public/assets/hero-bg-lines.svg
@@ -1,0 +1,79 @@
+<svg width="1440" height="900" viewBox="0 0 1440 900" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M63.6523 899.5L1623.19 0" stroke="url(#paint0_linear_6_19537)"/>
+<path d="M-120 899.5L1439.54 0" stroke="url(#paint1_linear_6_19537)"/>
+<path d="M443.102 899.5L2002.64 0" stroke="url(#paint2_linear_6_19537)"/>
+<path d="M255 899.5L1814.54 0" stroke="url(#paint3_linear_6_19537)"/>
+<path d="M843.422 899.5L2402.96 0" stroke="url(#paint4_linear_6_19537)"/>
+<path d="M650 899.5L2209.54 0" stroke="url(#paint5_linear_6_19537)"/>
+<path d="M1328.48 899.5L2888.02 0" stroke="url(#paint6_linear_6_19537)"/>
+<path d="M-290.008 899.5L1269.53 0" stroke="url(#paint7_linear_6_19537)"/>
+<path d="M-479 899.5L1080.54 0" stroke="url(#paint8_linear_6_19537)"/>
+<path d="M-668.23 899.5L891.312 0" stroke="url(#paint9_linear_6_19537)"/>
+<path d="M-875 899.5L684.543 0" stroke="url(#paint10_linear_6_19537)"/>
+<path d="M-1069.78 899.5L489.761 0" stroke="url(#paint11_linear_6_19537)"/>
+<path d="M-1259 899.5L300.543 0" stroke="url(#paint12_linear_6_19537)"/>
+<path d="M-1448 899.5L111.543 0" stroke="url(#paint13_linear_6_19537)"/>
+<path d="M1070 899.5L2629.54 0" stroke="url(#paint14_linear_6_19537)"/>
+<defs>
+<linearGradient id="paint0_linear_6_19537" x1="843.424" y1="0" x2="843.424" y2="899.5" gradientUnits="userSpaceOnUse">
+<stop stop-color="#403F42" stop-opacity="0"/>
+<stop offset="1" stop-color="#403F42"/>
+</linearGradient>
+<linearGradient id="paint1_linear_6_19537" x1="659.771" y1="0" x2="659.771" y2="899.5" gradientUnits="userSpaceOnUse">
+<stop stop-color="#403F42" stop-opacity="0"/>
+<stop offset="1" stop-color="#403F42"/>
+</linearGradient>
+<linearGradient id="paint2_linear_6_19537" x1="1222.87" y1="0" x2="1222.87" y2="899.5" gradientUnits="userSpaceOnUse">
+<stop stop-color="#403F42" stop-opacity="0"/>
+<stop offset="1" stop-color="#403F42"/>
+</linearGradient>
+<linearGradient id="paint3_linear_6_19537" x1="1034.77" y1="0" x2="1034.77" y2="899.5" gradientUnits="userSpaceOnUse">
+<stop stop-color="#403F42" stop-opacity="0"/>
+<stop offset="1" stop-color="#403F42"/>
+</linearGradient>
+<linearGradient id="paint4_linear_6_19537" x1="1623.19" y1="0" x2="1623.19" y2="899.5" gradientUnits="userSpaceOnUse">
+<stop stop-color="#403F42" stop-opacity="0"/>
+<stop offset="1" stop-color="#403F42"/>
+</linearGradient>
+<linearGradient id="paint5_linear_6_19537" x1="1429.77" y1="0" x2="1429.77" y2="899.5" gradientUnits="userSpaceOnUse">
+<stop stop-color="#403F42" stop-opacity="0"/>
+<stop offset="1" stop-color="#403F42"/>
+</linearGradient>
+<linearGradient id="paint6_linear_6_19537" x1="2108.25" y1="0" x2="2108.25" y2="899.5" gradientUnits="userSpaceOnUse">
+<stop stop-color="#403F42" stop-opacity="0"/>
+<stop offset="1" stop-color="#403F42"/>
+</linearGradient>
+<linearGradient id="paint7_linear_6_19537" x1="489.763" y1="0" x2="489.763" y2="899.5" gradientUnits="userSpaceOnUse">
+<stop stop-color="#403F42" stop-opacity="0"/>
+<stop offset="1" stop-color="#403F42"/>
+</linearGradient>
+<linearGradient id="paint8_linear_6_19537" x1="300.771" y1="0" x2="300.771" y2="899.5" gradientUnits="userSpaceOnUse">
+<stop stop-color="#403F42" stop-opacity="0"/>
+<stop offset="1" stop-color="#403F42"/>
+</linearGradient>
+<linearGradient id="paint9_linear_6_19537" x1="111.541" y1="0" x2="111.541" y2="899.5" gradientUnits="userSpaceOnUse">
+<stop stop-color="#403F42" stop-opacity="0"/>
+<stop offset="1" stop-color="#403F42"/>
+</linearGradient>
+<linearGradient id="paint10_linear_6_19537" x1="-95.2287" y1="0" x2="-95.2287" y2="899.5" gradientUnits="userSpaceOnUse">
+<stop stop-color="#403F42" stop-opacity="0"/>
+<stop offset="1" stop-color="#403F42"/>
+</linearGradient>
+<linearGradient id="paint11_linear_6_19537" x1="-290.01" y1="0" x2="-290.01" y2="899.5" gradientUnits="userSpaceOnUse">
+<stop stop-color="#403F42" stop-opacity="0"/>
+<stop offset="1" stop-color="#403F42"/>
+</linearGradient>
+<linearGradient id="paint12_linear_6_19537" x1="-479.229" y1="0" x2="-479.229" y2="899.5" gradientUnits="userSpaceOnUse">
+<stop stop-color="#403F42" stop-opacity="0"/>
+<stop offset="1" stop-color="#403F42"/>
+</linearGradient>
+<linearGradient id="paint13_linear_6_19537" x1="-668.229" y1="0" x2="-668.229" y2="899.5" gradientUnits="userSpaceOnUse">
+<stop stop-color="#403F42" stop-opacity="0"/>
+<stop offset="1" stop-color="#403F42"/>
+</linearGradient>
+<linearGradient id="paint14_linear_6_19537" x1="1849.77" y1="0" x2="1849.77" y2="899.5" gradientUnits="userSpaceOnUse">
+<stop stop-color="#403F42" stop-opacity="0"/>
+<stop offset="1" stop-color="#403F42"/>
+</linearGradient>
+</defs>
+</svg>


### PR DESCRIPTION
This change enforces the background lines on the background hero. 

Breaking changes: N/A

Note: 
It should be noted that the Lottie file has a transparent fill, so the lines overlap.

![image](https://user-images.githubusercontent.com/96435344/209225522-21b9bc9b-e86c-4f4d-8a8d-ec1590096bf3.png)
