### PR TITLE
fix: lottie memory leak

### DIFF
--- a/components/Hero/Hero.tsx
+++ b/components/Hero/Hero.tsx
@@ -1,14 +1,18 @@
 import { BaseOuterWrapper } from "components/style/Wrappers";
 import { laptopAndUnder, mobileAndUnder, tabletAndUnder } from "constant";
-import { motion } from "framer-motion";
-import Lottie from "react-lottie-player";
+import { motion, useInView } from "framer-motion";
 import NextLink from "next/link";
 import DownArrow from "public/assets/down-arrow.svg";
 import heroAnimation from "public/assets/lottie/hero_animation.json";
 import OOLogo from "public/assets/oo-logo.svg";
+import { useRef } from "react";
+import Lottie from "react-lottie-player";
 import styled, { keyframes } from "styled-components";
 
 export function Hero() {
+  const ref = useRef<HTMLDivElement>(null);
+  const isInView = useInView(ref);
+
   const headerAnimation = {
     initial: {
       opacity: 0,
@@ -40,13 +44,13 @@ export function Hero() {
   }
 
   return (
-    <OuterWrapper>
+    <OuterWrapper ref={ref}>
       <Background
         initial={{ opacity: 0, translateX: "-10%", translateY: "10%" }}
         animate={{ opacity: 0.15, translateX: "0%", translateY: "0%" }}
         transition={{ duration: 0.5 }}
       >
-        <LottieHeroAnimation play animationData={heroAnimation} />
+        <LottieHeroAnimation play={isInView} animationData={heroAnimation} />
       </Background>
       <InnerWrapper>
         <HeaderWrapper {...headerAnimation}>

--- a/components/Hero/Hero.tsx
+++ b/components/Hero/Hero.tsx
@@ -1,7 +1,7 @@
 import { BaseOuterWrapper } from "components/style/Wrappers";
 import { laptopAndUnder, mobileAndUnder, tabletAndUnder } from "constant";
 import { motion } from "framer-motion";
-import Lottie from "lottie-react";
+import Lottie from "react-lottie-player";
 import NextLink from "next/link";
 import DownArrow from "public/assets/down-arrow.svg";
 import heroAnimation from "public/assets/lottie/hero_animation.json";
@@ -46,7 +46,7 @@ export function Hero() {
         animate={{ opacity: 0.15, translateX: "0%", translateY: "0%" }}
         transition={{ duration: 0.5 }}
       >
-        <LottieHeroAnimation loop={true} autoplay={true} animationData={heroAnimation} />
+        <LottieHeroAnimation play animationData={heroAnimation} />
       </Background>
       <InnerWrapper>
         <HeaderWrapper {...headerAnimation}>

--- a/components/HowItWorks/HowItWorks.tsx
+++ b/components/HowItWorks/HowItWorks.tsx
@@ -2,7 +2,7 @@ import { SectionHeader } from "components/SectionHeader/SectionHeader";
 import { BaseOuterWrapper } from "components/style/Wrappers";
 import { laptopAndUnder, mobileAndUnder, tabletAndUnder } from "constant";
 import { useHeaderContext } from "hooks/contexts/useHeaderContext";
-import Lottie from "lottie-react";
+import Lottie from "react-lottie-player";
 import sceneOne from "public/assets/lottie/scene-1.json";
 import sceneTwo from "public/assets/lottie/scene-2.json";
 import sceneThree from "public/assets/lottie/scene-3.json";
@@ -76,8 +76,7 @@ export function HowItWorks() {
             <LottieWrapper>
               <Lottie
                 animationData={animationData}
-                loop={true}
-                autoplay={true}
+                play
                 rendererSettings={{
                   preserveAspectRatio: "xMidYMid slice",
                 }}

--- a/components/HowItWorks/HowItWorks.tsx
+++ b/components/HowItWorks/HowItWorks.tsx
@@ -1,18 +1,27 @@
 import { SectionHeader } from "components/SectionHeader/SectionHeader";
 import { BaseOuterWrapper } from "components/style/Wrappers";
 import { laptopAndUnder, mobileAndUnder, tabletAndUnder } from "constant";
+import { useInView } from "framer-motion";
 import { useHeaderContext } from "hooks/contexts/useHeaderContext";
-import Lottie from "react-lottie-player";
 import sceneOne from "public/assets/lottie/scene-1.json";
 import sceneTwo from "public/assets/lottie/scene-2.json";
 import sceneThree from "public/assets/lottie/scene-3.json";
 import sceneFour from "public/assets/lottie/scene-4.json";
 import { useEffect, useRef } from "react";
+import Lottie from "react-lottie-player";
 import styled, { CSSProperties } from "styled-components";
 
 export function HowItWorks() {
   const { setColorChangeSectionRef } = useHeaderContext();
   const howItWorksRef = useRef<HTMLDivElement>(null);
+  const step1Ref = useRef<HTMLDivElement>(null);
+  const step2Ref = useRef<HTMLDivElement>(null);
+  const step3Ref = useRef<HTMLDivElement>(null);
+  const step4Ref = useRef<HTMLDivElement>(null);
+  const step1IsInView = useInView(step1Ref);
+  const step2IsInView = useInView(step2Ref);
+  const step3IsInView = useInView(step3Ref);
+  const step4IsInView = useInView(step4Ref);
 
   useEffect(() => {
     setColorChangeSectionRef(howItWorksRef);
@@ -26,6 +35,8 @@ export function HowItWorks() {
       subText:
         "A natural-language statement is submitted along with a bond. The bond acts as a bounty for anyone to dispute it if they have evidence to the contrary.",
       animationData: sceneOne,
+      ref: step1Ref,
+      play: step1IsInView,
     },
     {
       header: "Challenge period",
@@ -33,6 +44,8 @@ export function HowItWorks() {
       subText:
         "Anyone can propose an answer to a data request, and it is accepted as true if it is not disputed during the challenge period.",
       animationData: sceneTwo,
+      ref: step2Ref,
+      play: step2IsInView,
     },
     {
       header: "Dispute",
@@ -41,6 +54,8 @@ export function HowItWorks() {
       successfully. As the game theory would predict, disputes are rare in practice because the incentives are
       always to be honest. That makes the OO “optimistic”.`,
       animationData: sceneThree,
+      ref: step3Ref,
+      play: step3IsInView,
     },
     {
       header: "Voting",
@@ -49,6 +64,8 @@ export function HowItWorks() {
       the human component, as voters, for the OO&apos;s final resolution on disputes or queries. Those who vote
       with the majority earn rewards.`,
       animationData: sceneFour,
+      ref: step4Ref,
+      play: step4IsInView,
     },
   ];
 
@@ -62,8 +79,8 @@ export function HowItWorks() {
     <OuterWrapper ref={howItWorksRef} id="how-it-works" style={style}>
       <InnerWrapper>
         <SectionHeader title="How it works" header="The Optimistic Oracle verifies data in stages" />
-        {steps.map(({ header, text, subText, animationData }, index, arr) => (
-          <StepWrapper key={header}>
+        {steps.map(({ header, text, subText, animationData, ref, play }, index, arr) => (
+          <StepWrapper ref={ref} key={header}>
             <StepNumberWrapper>
               <StepNumber invert={index % 2 === 1}>0{index + 1}</StepNumber>
               {index < arr.length - 1 && <StepLine invert={index % 2 === 1} />}
@@ -76,7 +93,7 @@ export function HowItWorks() {
             <LottieWrapper>
               <Lottie
                 animationData={animationData}
-                play
+                play={play}
                 rendererSettings={{
                   preserveAspectRatio: "xMidYMid slice",
                 }}

--- a/components/VoteParticipation/VoteParticipation.tsx
+++ b/components/VoteParticipation/VoteParticipation.tsx
@@ -3,40 +3,56 @@ import { SectionHeader } from "components/SectionHeader/SectionHeader";
 import { BaseOuterWrapper } from "components/style/Wrappers";
 import { mobileAndUnder, tabletAndUnder } from "constant";
 import { useVotingInfo } from "hooks";
-import Lottie, { LottieRefCurrentProps } from "lottie-react";
 import earn from "public/assets/lottie/earn.json";
 import stake from "public/assets/lottie/stake.json";
 import vote from "public/assets/lottie/vote.json";
-import { useRef } from "react";
+import { useState } from "react";
+import Lottie from "react-lottie-player";
 import styled from "styled-components";
 
 export function VoteParticipation() {
   const {
     data: { apy },
   } = useVotingInfo();
-  const stakeRef = useRef<LottieRefCurrentProps>(null);
-  const voteRef = useRef<LottieRefCurrentProps>(null);
-  const earnRef = useRef<LottieRefCurrentProps>(null);
+  const [playStake, setPlayStake] = useState(false);
+  const [playVote, setPlayVote] = useState(false);
+  const [playEarn, setPlayEarn] = useState(false);
+  // lottie uses 1 and -1 to indicate direction
+  const forward = 1;
+  const backward = -1;
+  type Direction = typeof forward | typeof backward;
+  const [stakeDirection, setStakeDirection] = useState<Direction>(forward);
+  const [voteDirection, setVoteDirection] = useState<Direction>(forward);
+  const [earnDirection, setEarnDirection] = useState<Direction>(forward);
 
   const activities = [
     {
       title: "Stake",
       text: "Stake your $UMA to help secure UMA's Optimistic Oracle.",
       animationData: stake,
-      ref: stakeRef,
+      play: playStake,
+      setPlay: setPlayStake,
+      direction: stakeDirection,
+      setDirection: setStakeDirection,
     },
     {
       title: "Vote",
       text: "Token holders who vote correctly and consistently earn higher APYs.",
       animationData: vote,
-      ref: voteRef,
+      play: playVote,
+      setPlay: setPlayVote,
+      direction: voteDirection,
+      setDirection: setVoteDirection,
     },
     {
       title: "Earn",
       text: `Successful voters will gradually own a higher percentage of the protocol than unsuccessful or inactive
       voters.`,
       animationData: earn,
-      ref: earnRef,
+      play: playEarn,
+      setPlay: setPlayEarn,
+      direction: earnDirection,
+      setDirection: setEarnDirection,
     },
   ];
 
@@ -50,23 +66,23 @@ export function VoteParticipation() {
         />
 
         <ActivitiesWrapper>
-          {activities.map(({ title, text, animationData, ref }) => (
+          {activities.map(({ title, text, animationData, play, setPlay, direction, setDirection }) => (
             <Activity
               key={title}
               onMouseOver={() => {
-                ref.current?.setDirection(1);
-                ref.current?.play();
+                setDirection(forward);
+                setPlay(true);
               }}
               onMouseOut={() => {
-                ref.current?.setDirection(-1);
-                ref.current?.play();
+                setDirection(backward);
+                setPlay(true);
               }}
             >
               <LottieWrapper>
                 <LottieAnimation
-                  lottieRef={ref}
                   loop={false}
-                  autoplay={false}
+                  play={play}
+                  direction={direction}
                   animationData={animationData}
                   rendererSettings={{
                     preserveAspectRatio: "xMidYMid slice",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-focus-on": "^3.7.0",
+    "react-lottie-player": "^1.5.4",
     "react-mailchimp-subscribe": "^2.1.3",
     "styled-components": "^5.3.6"
   },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@tanstack/react-query": "^4.19.1",
     "@tanstack/react-query-devtools": "^4.19.1",
     "framer-motion": "^7.8.0",
-    "lottie-react": "^2.3.1",
     "luxon": "^3.1.1",
     "next": "13.0.6",
     "react": "18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8769,6 +8769,11 @@ lottie-react@^2.3.1:
   dependencies:
     lottie-web "^5.9.4"
 
+lottie-web@^5.7.6:
+  version "5.10.1"
+  resolved "https://registry.yarnpkg.com/lottie-web/-/lottie-web-5.10.1.tgz#fde8e6be374afc3906f78b4152ada9be44ce3ccf"
+  integrity sha512-u17bVNf/vA3oK9Wkyb1Vpo83WUIEQwaT0GeEN0qcvaExizyJ/RjmcbjSDj0CnwQCtpGqTgYhqprCC7cTWuXMNw==
+
 lottie-web@^5.9.4:
   version "5.10.0"
   resolved "https://registry.yarnpkg.com/lottie-web/-/lottie-web-5.10.0.tgz#72563f22efdcf2b8f7e8359743514930ebaf5f8c"
@@ -10453,6 +10458,15 @@ react-is@^16.13.1, react-is@^16.7.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-lottie-player@^1.5.4:
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/react-lottie-player/-/react-lottie-player-1.5.4.tgz#8205cc334d11b923d9bac78e1d19bcc0d475d751"
+  integrity sha512-eM0g11bAc4EJJuDDfCoNloaAYphfXlIpYnriOt4nRU66PpVmvKhajvP2aif4YflGY2ArAFXhWxs418YzdebK9w==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    lottie-web "^5.7.6"
+    rfdc "^1.3.0"
+
 react-mailchimp-subscribe@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/react-mailchimp-subscribe/-/react-mailchimp-subscribe-2.1.3.tgz#2f195f20b98c9be9608fac95d1f4f5bcb2d81929"
@@ -10854,6 +10868,11 @@ reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
+rfdc@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.3.0.tgz#d0b7c441ab2720d05dc4cf26e01c89631d9da08b"
+  integrity sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==
 
 rimraf@^2.5.4, rimraf@^2.6.3:
   version "2.7.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8762,22 +8762,10 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
-lottie-react@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/lottie-react/-/lottie-react-2.3.1.tgz#697060417bab027edb57ed45bda9d62e920d4040"
-  integrity sha512-8cxd6XZZtECT6LoAhCftRdYrEpHxiouvB5EPiYA+TtCG5LHNYAdMS9IVIHcxKtWnpo7x16QfCLj1XLXZpaN81A==
-  dependencies:
-    lottie-web "^5.9.4"
-
 lottie-web@^5.7.6:
   version "5.10.1"
   resolved "https://registry.yarnpkg.com/lottie-web/-/lottie-web-5.10.1.tgz#fde8e6be374afc3906f78b4152ada9be44ce3ccf"
   integrity sha512-u17bVNf/vA3oK9Wkyb1Vpo83WUIEQwaT0GeEN0qcvaExizyJ/RjmcbjSDj0CnwQCtpGqTgYhqprCC7cTWuXMNw==
-
-lottie-web@^5.9.4:
-  version "5.10.0"
-  resolved "https://registry.yarnpkg.com/lottie-web/-/lottie-web-5.10.0.tgz#72563f22efdcf2b8f7e8359743514930ebaf5f8c"
-  integrity sha512-q2hfqKrGXNkwjSSZjKxf3fWMi0e3ZBc03qBkVWoGbwUJ7BcG+9YXjMPtmmhitzk8Nc6VQ5PRnh9yInPdfq0PZg==
 
 loud-rejection@^1.0.0:
   version "1.6.0"


### PR DESCRIPTION
### Summary

I noticed that we had very high memory use on the page (>800mb) and it was always climbing — classic memory leak. I used the profiler to discover the culprit, which was the lottie animations. It turns out that when lottie animations use something called "repeaters" they will create new instances of the json data over and over again, leading to a leak. See [this issue](https://github.com/airbnb/lottie-web/issues/2070) for details.

I fixed the issue by switching to [this library](https://www.npmjs.com/package/react-lottie-player) which specifically deals with this problem. It also has a better api too, so even better to make the switch.