### PR TITLE
feat: heading reveal and circle animation

### DIFF
--- a/components/Builder/Builder.tsx
+++ b/components/Builder/Builder.tsx
@@ -1,15 +1,16 @@
 import { Tabs } from "components";
+import { SectionHeader } from "components/SectionHeader/SectionHeader";
+import { BaseOuterWrapper } from "components/style/Wrappers";
 import { laptopAndUnder, mobileAndUnder, tabletAndUnder } from "constant";
 import OO from "public/assets/oo-logo.svg";
 import styled from "styled-components";
-import { BaseOuterWrapper } from "components/style/Wrappers";
-import { SectionHeader } from "components/SectionHeader/SectionHeader";
 
 export function Builder() {
   return (
     <OuterWrapper id="builder">
       <InnerWrapper>
         <SectionHeader
+          hasCircleFilter={false}
           title={{ text: "Participate as a", redSuffix: "Builder" }}
           header={
             <>
@@ -29,7 +30,7 @@ export function Builder() {
 }
 
 const OuterWrapper = styled(BaseOuterWrapper)`
-  background: var(--white);
+  background: linear-gradient(180deg, var(--white) 0%, var(--white-200) 50%, var(--white) 100%);
 `;
 
 const InnerWrapper = styled.div`

--- a/components/HowItWorks/HowItWorks.tsx
+++ b/components/HowItWorks/HowItWorks.tsx
@@ -103,7 +103,7 @@ function Step({ header, text, subText, animationData, index }: StepProps) {
     target: lineRef,
     offset: ["-100%", "start"],
   });
-  const scaleY = useSpring(scrollYProgress, {
+  const spring = useSpring(scrollYProgress, {
     stiffness: 100,
     damping: 30,
     restDelta: 0.001,
@@ -123,11 +123,12 @@ function Step({ header, text, subText, animationData, index }: StepProps) {
             color: white,
             border: `1px solid ${red}`,
           }}
+          transition={spring}
         >
           0{index + 1}
         </StepNumber>
         <StepLineOuter ref={lineRef}>
-          <StepLineInner style={{ scaleY }} />
+          <StepLineInner style={{ scaleY: spring }} />
         </StepLineOuter>
       </StepNumberWrapper>
       <StepDescription>

--- a/components/HowItWorks/HowItWorks.tsx
+++ b/components/HowItWorks/HowItWorks.tsx
@@ -134,7 +134,7 @@ function Step({ header, text, subText, animationData, index }: StepProps) {
 }
 
 const OuterWrapper = styled(BaseOuterWrapper)`
-  background: linear-gradient(180deg, var(--white) 0%, var(--white-200) 100%);
+  background: linear-gradient(180deg, var(--white) 0%, var(--white-200) 50%, var(--white) 100%);
 `;
 
 const InnerWrapper = styled.div`

--- a/components/HowItWorks/HowItWorks.tsx
+++ b/components/HowItWorks/HowItWorks.tsx
@@ -14,14 +14,6 @@ import styled from "styled-components";
 export function HowItWorks() {
   const { setColorChangeSectionRef } = useHeaderContext();
   const howItWorksRef = useRef<HTMLDivElement>(null);
-  const step1Ref = useRef<HTMLDivElement>(null);
-  const step2Ref = useRef<HTMLDivElement>(null);
-  const step3Ref = useRef<HTMLDivElement>(null);
-  const step4Ref = useRef<HTMLDivElement>(null);
-  const step1IsInView = useInView(step1Ref);
-  const step2IsInView = useInView(step2Ref);
-  const step3IsInView = useInView(step3Ref);
-  const step4IsInView = useInView(step4Ref);
 
   useEffect(() => {
     setColorChangeSectionRef(howItWorksRef);
@@ -35,8 +27,6 @@ export function HowItWorks() {
       subText:
         "A natural-language statement is submitted along with a bond. The bond acts as a bounty for anyone to dispute it if they have evidence to the contrary.",
       animationData: sceneOne,
-      ref: step1Ref,
-      play: step1IsInView,
     },
     {
       header: "Challenge period",
@@ -44,8 +34,6 @@ export function HowItWorks() {
       subText:
         "Anyone can propose an answer to a data request, and it is accepted as true if it is not disputed during the challenge period.",
       animationData: sceneTwo,
-      ref: step2Ref,
-      play: step2IsInView,
     },
     {
       header: "Dispute",
@@ -54,8 +42,6 @@ export function HowItWorks() {
       successfully. As the game theory would predict, disputes are rare in practice because the incentives are
       always to be honest. That makes the OO “optimistic”.`,
       animationData: sceneThree,
-      ref: step3Ref,
-      play: step3IsInView,
     },
     {
       header: "Voting",
@@ -64,8 +50,6 @@ export function HowItWorks() {
       the human component, as voters, for the OO&apos;s final resolution on disputes or queries. Those who vote
       with the majority earn rewards.`,
       animationData: sceneFour,
-      ref: step4Ref,
-      play: step4IsInView,
     },
   ];
 

--- a/components/SectionHeader/SectionHeader.tsx
+++ b/components/SectionHeader/SectionHeader.tsx
@@ -1,8 +1,11 @@
 import { laptopAndUnder, mobileAndUnder, tabletAndUnder } from "constant";
 import { motion } from "framer-motion";
+import { useState } from "react";
 import styled, { CSSProperties } from "styled-components";
 
-const HeaderWrapper = styled.div``;
+const HeaderWrapper = styled.div`
+  position: relative;
+`;
 
 const Title = styled(motion.h1)`
   font: var(--header-sm);
@@ -48,9 +51,10 @@ type SectionHeaderProps = {
       };
   header: string | JSX.Element;
   constrainWidth?: boolean;
+  hasCircleFilter?: boolean;
 };
 
-export function SectionHeader({ title, header, constrainWidth }: SectionHeaderProps) {
+export function SectionHeader({ title, header, constrainWidth, hasCircleFilter = true }: SectionHeaderProps) {
   return (
     <HeaderWrapper>
       <Title
@@ -79,7 +83,61 @@ export function SectionHeader({ title, header, constrainWidth }: SectionHeaderPr
         }
       >
         {header}
+        {hasCircleFilter && <CircleFilter />}
       </Header>
     </HeaderWrapper>
   );
 }
+
+function CircleFilter() {
+  const [showCircle, setShowCircle] = useState(false);
+  const [{ x, y }, setMousePosition] = useState({ x: 0, y: 0 });
+
+  return (
+    <CircleFilterWrapper
+      onMouseEnter={() => {
+        setShowCircle(true);
+      }}
+      onMouseLeave={() => {
+        setShowCircle(false);
+      }}
+      onMouseMove={(e) => {
+        const rect = e.currentTarget.getBoundingClientRect();
+        setMousePosition({ x: e.clientX - rect.left, y: e.clientY - rect.top });
+      }}
+    >
+      <Circle
+        style={
+          {
+            opacity: showCircle ? 1 : 0,
+            "--x-pos": x.toFixed() + "px",
+            "--y-pos": y.toFixed() + "px",
+          } as CSSProperties
+        }
+      />
+    </CircleFilterWrapper>
+  );
+}
+
+const CircleFilterWrapper = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+`;
+
+const Circle = styled.div`
+  position: absolute;
+  --height: 200px;
+  --half-height: calc(var(--height) / 2);
+  height: var(--height);
+  top: calc(var(--y-pos) - var(--half-height));
+  left: calc(var(--x-pos) - var(--half-height));
+  aspect-ratio: 1/1;
+  border-radius: 50%;
+  backdrop-filter: brightness(2) saturate(20) hue-rotate(76.5deg);
+  transition: opacity var(--animation-duration);
+  pointer-events: none;
+`;

--- a/components/SectionHeader/SectionHeader.tsx
+++ b/components/SectionHeader/SectionHeader.tsx
@@ -1,9 +1,10 @@
-import { mobileAndUnder, laptopAndUnder, tabletAndUnder } from "constant";
-import styled from "styled-components";
+import { laptopAndUnder, mobileAndUnder, tabletAndUnder } from "constant";
+import { motion } from "framer-motion";
+import styled, { CSSProperties } from "styled-components";
 
 const HeaderWrapper = styled.div``;
 
-const Title = styled.h1`
+const Title = styled(motion.h1)`
   font: var(--header-sm);
   padding-bottom: 16px;
   border-bottom: 1px solid var(--grey-600);
@@ -12,13 +13,12 @@ const Title = styled.h1`
   }
 `;
 
-const Header = styled.h2<{ constrainWidth?: boolean }>`
+const Header = styled(motion.h2)`
   --width-desktop-tablet: 1020px;
   --width-laptop: 720px;
   --width-mobile: 100%;
   --width: var(--width-desktop-tablet);
-  max-width: var(--width);
-  max-width: ${({ constrainWidth }) => (constrainWidth ? "max(70%, 720px)" : "var(--width)")};
+  max-width: var(--max-width);
   margin-top: 48px;
   margin-bottom: 128px;
   font: var(--header-lg);
@@ -53,7 +53,12 @@ type SectionHeaderProps = {
 export function SectionHeader({ title, header, constrainWidth }: SectionHeaderProps) {
   return (
     <HeaderWrapper>
-      <Title>
+      <Title
+        initial={{ opacity: 0.1, rotate: "-2deg" }}
+        whileInView={{ opacity: 1, rotate: "0deg" }}
+        viewport={{ once: true, amount: "all" }}
+        transition={{ duration: 0.6 }}
+      >
         {typeof title === "string" ? (
           title
         ) : (
@@ -62,7 +67,19 @@ export function SectionHeader({ title, header, constrainWidth }: SectionHeaderPr
           </>
         )}
       </Title>
-      <Header constrainWidth={constrainWidth}>{header}</Header>
+      <Header
+        initial={{ opacity: 0.1, rotate: "1deg" }}
+        whileInView={{ opacity: 1, rotate: "0deg" }}
+        viewport={{ once: true, amount: "all" }}
+        transition={{ duration: 0.6 }}
+        style={
+          {
+            "--max-width": constrainWidth ? "max(70%, 720px)" : "var(--width)",
+          } as CSSProperties
+        }
+      >
+        {header}
+      </Header>
     </HeaderWrapper>
   );
 }

--- a/components/VoteParticipation/VoteParticipation.tsx
+++ b/components/VoteParticipation/VoteParticipation.tsx
@@ -108,7 +108,7 @@ export function VoteParticipation() {
 }
 
 const OuterWrapper = styled(BaseOuterWrapper)`
-  background: linear-gradient(180deg, #fafafa 0%, #ffffff 100%);
+  background: var(--white);
 `;
 
 const InnerWrapper = styled.div`

--- a/components/VoteTicker/VoteTicker.tsx
+++ b/components/VoteTicker/VoteTicker.tsx
@@ -35,7 +35,7 @@ export function VoteTicker({ isLightTheme = false }) {
 
   return (
     <OuterWrapper
-      initial={{ opacity: 0, translateY: "-100%" }}
+      initial={{ opacity: 0, translateY: "-20px" }}
       animate={{ opacity: 1, translateY: "0%" }}
       transition={{ duration: 0.5, delay: 1 }}
       style={


### PR DESCRIPTION
Adds entry animations for the section headers that are triggered when they enter the viewport.

Adds the mouse-mapped circle hue-rotate effect from the designs.

![Screenshot 2023-01-06 at 14 03 39](https://user-images.githubusercontent.com/39741965/211009377-708801c2-891d-4ace-8972-67b0391c0698.png)
