### PR TITLE
feat: make links active when scrolling sections

### DIFF
--- a/components/Builder/Builder.tsx
+++ b/components/Builder/Builder.tsx
@@ -2,12 +2,18 @@ import { Tabs } from "components";
 import { SectionHeader } from "components/SectionHeader/SectionHeader";
 import { BaseOuterWrapper } from "components/style/Wrappers";
 import { laptopAndUnder, mobileAndUnder, tabletAndUnder } from "constant";
+import { useAddHashToUrl } from "hooks/helpers/useAddHashToUrl";
 import OO from "public/assets/oo-logo.svg";
+import { useRef } from "react";
 import styled from "styled-components";
 
 export function Builder() {
+  const id = "builder";
+  const ref = useRef<HTMLDivElement>(null);
+  useAddHashToUrl(id, ref);
+
   return (
-    <OuterWrapper id="builder">
+    <OuterWrapper ref={ref} id={id}>
       <InnerWrapper>
         <SectionHeader
           hasCircleFilter={false}

--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -1,15 +1,21 @@
 import { MailChimpForm, VoteTicker } from "components";
 import { BaseOuterWrapper } from "components/style/Wrappers";
 import { footerLinks, laptopAndUnder, mobileAndUnder, socialLinks, tabletAndUnder } from "constant";
+import { useAddHashToUrl } from "hooks/helpers/useAddHashToUrl";
 import NextLink from "next/link";
 import UmaLogo from "public/assets/uma-logo.svg";
 import UpRightArrowBlack from "public/assets/up-right-arrow-black.svg";
+import { useRef } from "react";
 import styled from "styled-components";
 import { isExternalLink } from "utils";
 
 export function Footer() {
+  const id = "contact";
+  const ref = useRef<HTMLDivElement>(null);
+  useAddHashToUrl(id, ref);
+
   return (
-    <OuterWrapper as="footer">
+    <OuterWrapper id={id} ref={ref} as="footer">
       <VoteTickerWrapper>
         <VoteTicker isLightTheme />
       </VoteTickerWrapper>

--- a/components/Header/DesktopHeader.tsx
+++ b/components/Header/DesktopHeader.tsx
@@ -1,20 +1,21 @@
 import { grey100, grey400, links, red, tabletAndUnder, white } from "constant";
 import NextLink from "next/link";
-import { useRouter } from "next/router";
+import SmUpRightArrow from "public/assets/sm-up-right-arrow.svg";
 import BlackLogo from "public/assets/uma-black-logo.svg";
 import Logo from "public/assets/uma-white-logo.svg";
 import { CSSProperties } from "react";
 import styled from "styled-components";
 import { isExternalLink } from "utils";
-import SmUpRightArrow from "public/assets/sm-up-right-arrow.svg";
 
 interface Props {
   isLightTheme: boolean;
 }
 
 export function DesktopHeader({ isLightTheme }: Props) {
-  const router = useRouter();
-  const isActive = (href: string) => router.asPath === `/${href}`;
+  const isActive = (href: string) => {
+    if (typeof window === "undefined") return false;
+    return window.location.href.includes(href);
+  };
 
   return (
     <Wrapper>

--- a/components/Header/DesktopHeader.tsx
+++ b/components/Header/DesktopHeader.tsx
@@ -12,10 +12,10 @@ interface Props {
 }
 
 export function DesktopHeader({ isLightTheme }: Props) {
-  const isActive = (href: string) => {
+  function isActive(href: string) {
     if (typeof window === "undefined") return false;
     return window.location.href.includes(href);
-  };
+  }
 
   return (
     <Wrapper>

--- a/components/Hero/Hero.tsx
+++ b/components/Hero/Hero.tsx
@@ -13,7 +13,7 @@ import styled, { keyframes } from "styled-components";
 export function Hero() {
   const ref = useRef<HTMLDivElement>(null);
   const isInView = useInView(ref);
-  useAddHashToUrl("", ref, 0.7);
+  useAddHashToUrl("", ref);
 
   const headerAnimation = {
     initial: {

--- a/components/Hero/Hero.tsx
+++ b/components/Hero/Hero.tsx
@@ -1,6 +1,7 @@
 import { BaseOuterWrapper } from "components/style/Wrappers";
 import { laptopAndUnder, mobileAndUnder, tabletAndUnder } from "constant";
 import { motion, useInView } from "framer-motion";
+import { useAddHashToUrl } from "hooks/helpers/useAddHashToUrl";
 import NextLink from "next/link";
 import DownArrow from "public/assets/down-arrow.svg";
 import heroAnimation from "public/assets/lottie/hero_animation.json";
@@ -12,6 +13,7 @@ import styled, { keyframes } from "styled-components";
 export function Hero() {
   const ref = useRef<HTMLDivElement>(null);
   const isInView = useInView(ref);
+  useAddHashToUrl("", ref, 0.7);
 
   const headerAnimation = {
     initial: {

--- a/components/HowItWorks/HowItWorks.tsx
+++ b/components/HowItWorks/HowItWorks.tsx
@@ -3,6 +3,7 @@ import { BaseOuterWrapper } from "components/style/Wrappers";
 import { grey500, laptopAndUnder, mobileAndUnder, red, tabletAndUnder, white } from "constant";
 import { motion, useInView, useScroll, useSpring } from "framer-motion";
 import { useHeaderContext } from "hooks/contexts/useHeaderContext";
+import { useAddHashToUrl } from "hooks/helpers/useAddHashToUrl";
 import sceneOne from "public/assets/lottie/scene-1.json";
 import sceneTwo from "public/assets/lottie/scene-2.json";
 import sceneThree from "public/assets/lottie/scene-3.json";
@@ -13,12 +14,15 @@ import styled from "styled-components";
 
 export function HowItWorks() {
   const { setColorChangeSectionRef } = useHeaderContext();
-  const howItWorksRef = useRef<HTMLDivElement>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const id = "how-it-works";
+
+  useAddHashToUrl(id, wrapperRef);
 
   useEffect(() => {
-    setColorChangeSectionRef(howItWorksRef);
+    setColorChangeSectionRef(wrapperRef);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [howItWorksRef.current]);
+  }, [wrapperRef.current]);
 
   const steps = [
     {
@@ -54,7 +58,7 @@ export function HowItWorks() {
   ];
 
   return (
-    <OuterWrapper ref={howItWorksRef} id="how-it-works">
+    <OuterWrapper ref={wrapperRef} id={id}>
       <InnerWrapper>
         <SectionHeader title="How it works" header="The Optimistic Oracle verifies data in stages" />
         {steps.map(({ header, text, subText, animationData }, index) => (

--- a/components/Projects/Projects.tsx
+++ b/components/Projects/Projects.tsx
@@ -2,6 +2,7 @@ import { AnimatedLink } from "components/AnimatedLink/AnimatedLink";
 import { Divider } from "components/Divider/Divider";
 import { BaseOuterWrapper } from "components/style/Wrappers";
 import { mobileAndUnder } from "constant";
+import { useAddHashToUrl } from "hooks/helpers/useAddHashToUrl";
 import NextLink from "next/link";
 import AcrossLogo from "public/assets/across.svg";
 import BobaLogo from "public/assets/boba.svg";
@@ -12,6 +13,7 @@ import PolymarketLogo from "public/assets/polymarket.svg";
 import ShapeshiftLogo from "public/assets/shapeshift.svg";
 import SherlockLogo from "public/assets/sherlock.svg";
 import UpRightArrow from "public/assets/up-right-arrow.svg";
+import { useRef } from "react";
 import styled, { CSSProperties } from "styled-components";
 
 type Project = {
@@ -21,6 +23,10 @@ type Project = {
 };
 
 export function Projects() {
+  const id = "projects";
+  const ref = useRef<HTMLDivElement>(null);
+  useAddHashToUrl(id, ref);
+
   const topRow = [
     {
       name: "Across",
@@ -71,7 +77,7 @@ export function Projects() {
   ];
 
   return (
-    <OuterWrapper>
+    <OuterWrapper id={id} ref={ref}>
       <InnerWrapper>
         <TextWrapper>
           <Header>Projects built with the OO</Header>

--- a/components/SupportSection/SupportSection.tsx
+++ b/components/SupportSection/SupportSection.tsx
@@ -1,11 +1,17 @@
 import { BaseOuterWrapper } from "components/style/Wrappers";
 import { mobileAndUnder, tabletAndUnder } from "constant";
+import { useAddHashToUrl } from "hooks/helpers/useAddHashToUrl";
 import UpRightArrowLg from "public/assets/up-right-arrow-lg.svg";
+import { useRef } from "react";
 import styled from "styled-components";
 
 export function SupportSection() {
+  const id = "support";
+  const ref = useRef<HTMLDivElement>(null);
+  useAddHashToUrl(id, ref);
+
   return (
-    <OuterWrapper>
+    <OuterWrapper id={id} ref={ref}>
       <Background>
         <Video autoPlay loop muted playsInline>
           <source src="/assets/uma.xyz.mp4" type="video/mp4" />

--- a/components/VoteParticipation/VoteParticipation.tsx
+++ b/components/VoteParticipation/VoteParticipation.tsx
@@ -3,14 +3,18 @@ import { SectionHeader } from "components/SectionHeader/SectionHeader";
 import { BaseOuterWrapper } from "components/style/Wrappers";
 import { mobileAndUnder, tabletAndUnder } from "constant";
 import { useVotingInfo } from "hooks";
+import { useAddHashToUrl } from "hooks/helpers/useAddHashToUrl";
 import earn from "public/assets/lottie/earn.json";
 import stake from "public/assets/lottie/stake.json";
 import vote from "public/assets/lottie/vote.json";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import Lottie from "react-lottie-player";
 import styled from "styled-components";
 
 export function VoteParticipation() {
+  const id = "voter";
+  const ref = useRef<HTMLDivElement>(null);
+  useAddHashToUrl(id, ref);
   const {
     data: { apy },
   } = useVotingInfo();
@@ -57,7 +61,7 @@ export function VoteParticipation() {
   ];
 
   return (
-    <OuterWrapper id="voter">
+    <OuterWrapper ref={ref} id={id}>
       <InnerWrapper>
         <SectionHeader
           title={{ text: "Participate as a", redSuffix: "Voter" }}

--- a/hooks/helpers/useAddHashToUrl.ts
+++ b/hooks/helpers/useAddHashToUrl.ts
@@ -1,0 +1,13 @@
+import { useInView } from "framer-motion";
+import { RefObject, useEffect } from "react";
+
+export function useAddHashToUrl(id: string, wrapperRef: RefObject<HTMLDivElement>, amount = 0.1) {
+  const isInView = useInView(wrapperRef, { amount });
+
+  useEffect(() => {
+    if (isInView) {
+      window.history.pushState({}, "", `#${id}`);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isInView]);
+}


### PR DESCRIPTION
Now when you scroll into a particular section, it adds the sections id to the url. This lets us determine that the link is active in the header, and highlight the appropriate link accordingly.

<img width="650" alt="Screenshot 2023-01-10 at 11 38 57" src="https://user-images.githubusercontent.com/39741965/211515788-67b0827d-2c55-45bb-80bc-72f14f513a88.png">
