### PR TITLE
improve: last tweaks

### DIFF
--- a/components/Builder.tsx
+++ b/components/Builder.tsx
@@ -1,4 +1,4 @@
-import { laptopAndUnder, mobileAndUnder, tabletAndUnder } from "constant";
+import { mobileAndUnder } from "constant";
 import { useLoadSectionRefAndId } from "hooks/helpers/useLoadSectionRefAndId";
 import dynamic from "next/dynamic";
 import OO from "public/assets/oo-logo.svg";
@@ -23,10 +23,7 @@ export default function Builder() {
           header={
             <>
               {" "}
-              <span>
-                Launch products with
-                <br /> the
-              </span>
+              <span>Launch products with the</span>
               <OOIconWrapper>
                 <OOIcon />
               </OOIconWrapper>
@@ -59,31 +56,16 @@ const OOIconWrapper = styled.span`
 `;
 
 const OOIcon = styled(OO)`
-  width: var(--width);
   height: var(--height);
-  --desktop-width: 164px;
-  --desktop-height: 82px;
-  --laptop-width: 124px;
-  --laptop-height: 62px;
-  --tablet-width: 114px;
-  --tablet-height: 57px;
-  --mobile-width: 64px;
-  --mobile-height: 32px;
-  --width: var(--desktop-width);
+  width: calc(var(--height) * 2);
+
+  height: var(--height);
+  --desktop-height: 5rem;
+  /* scales with the fluid typography on mobile by using the same clamp values */
+  --mobile-height: clamp(2.5rem, 7vw + 1.18rem, 4rem);
   --height: var(--desktop-height);
 
-  @media ${laptopAndUnder} {
-    --width: var(--laptop-width);
-    --height: var(--laptop-height);
-  }
-
-  @media ${tabletAndUnder} {
-    --width: var(--tablet-width);
-    --height: var(--tablet-height);
-  }
-
   @media ${mobileAndUnder} {
-    --width: var(--mobile-width);
     --height: var(--mobile-height);
   }
 `;

--- a/components/Builder.tsx
+++ b/components/Builder.tsx
@@ -1,4 +1,10 @@
-import { mobileAndUnder } from "constant";
+import {
+  headerLgFluidFontSize,
+  headerMdFluidFontSize,
+  headerSmFluidFontSize,
+  mobileAndUnder,
+  tabletAndUnder,
+} from "constant";
 import { useLoadSectionRefAndId } from "hooks/helpers/useLoadSectionRefAndId";
 import dynamic from "next/dynamic";
 import OO from "public/assets/oo-logo.svg";
@@ -60,10 +66,14 @@ const OOIcon = styled(OO)`
   width: calc(var(--height) * 2);
 
   height: var(--height);
-  --desktop-height: 5rem;
-  /* scales with the fluid typography on mobile by using the same clamp values */
-  --mobile-height: clamp(2.5rem, 7vw + 1.18rem, 4rem);
+  --desktop-height: ${headerLgFluidFontSize};
+  --tablet-height: ${headerMdFluidFontSize};
+  --mobile-height: ${headerSmFluidFontSize};
   --height: var(--desktop-height);
+
+  @media ${tabletAndUnder} {
+    --height: var(--tablet-height);
+  }
 
   @media ${mobileAndUnder} {
     --height: var(--mobile-height);

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -279,6 +279,7 @@ const OOLogoIcon = styled(OOLogo)`
   height: var(--height);
   --desktop-width: 166px;
   --desktop-height: 82px;
+  /* scales with the fluid typography on mobile by using the same clamp values */
   --mobile-height: clamp(2.5rem, 7vw + 1.18rem, 4rem);
   --mobile-width: calc(var(--mobile-height * 2));
   --width: var(--desktop-width);

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,4 +1,6 @@
 import {
+  headerLgFluid,
+  headerLgFluidFontSize,
   headerMdFluid,
   headerMdFluidFontSize,
   headerSmFluid,
@@ -163,6 +165,7 @@ const HeaderWrapper = styled(motion.div)`
 
 const Header = styled(motion.h1)`
   font: var(--header-lg);
+  ${headerLgFluid}
   color: var(--white);
   text-align: center;
   z-index: 1;
@@ -251,7 +254,7 @@ const OOLogoIcon = styled(OOLogo)`
   }
   width: calc(var(--height) * 2);
   height: var(--height);
-  --desktop-height: 6rem;
+  --desktop-height: ${headerLgFluidFontSize};
   --tablet-height: ${headerMdFluidFontSize};
   --mobile-height: ${headerSmFluidFontSize};
   --height: var(--desktop-height);

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,4 +1,11 @@
-import { mobileAndUnder, tabletAndUnder } from "constant";
+import {
+  headerMdFluid,
+  headerMdFluidFontSize,
+  headerSmFluid,
+  headerSmFluidFontSize,
+  mobileAndUnder,
+  tabletAndUnder,
+} from "constant";
 import { motion } from "framer-motion";
 import { useLoadSectionRefAndId } from "hooks/helpers/useLoadSectionRefAndId";
 import NextLink from "next/link";
@@ -159,44 +166,11 @@ const Header = styled(motion.h1)`
   color: var(--white);
   text-align: center;
   z-index: 1;
-  line-height: 115%;
   @media ${tabletAndUnder} {
-    font: var(--header-md);
-    line-height: 115%;
+    ${headerMdFluid}
   }
   @media ${mobileAndUnder} {
-    /* 
-      the formula for this fluid typography is as follows:
-
-      x — current viewport width value (px).
-      y — resulting fluid font size for a current viewport width value x (px).
-      v — viewport width value that affects fluid value change rate (vw).
-      r — relative size equal to browser font size. Default value is 16px.
-
-      to find v:
-
-      v = 100 * (y2-y1) / (x2-x1)
-
-      to find r:
-
-      r = (x1y2 - x2y1) / (x1 - x2)
-
-      and these values are used like so:
-
-      font-size: clamp([min]rem, [v]vw + [r]rem, [max]rem);
-
-      NOTE: the max and min font size values are used in px in the formula, but should be converted to rem when used
-
-      see https://www.smashingmagazine.com/2022/01/modern-fluid-typography-css-clamp/ for reference
-
-      in this case the values used were:
-
-      x1 = 300px
-      x2 = 620px
-      y1 = 40px
-      y2 = 64px
-    */
-    font-size: clamp(2.5rem, 7vw + 1.18rem, 4rem);
+    ${headerSmFluid}
   }
 `;
 
@@ -275,18 +249,18 @@ const OOLogoIcon = styled(OOLogo)`
   path {
     fill: var(--white);
   }
-  width: var(--width);
+  width: calc(var(--height) * 2);
   height: var(--height);
-  --desktop-width: 166px;
-  --desktop-height: 82px;
-  /* scales with the fluid typography on mobile by using the same clamp values */
-  --mobile-height: clamp(2.5rem, 7vw + 1.18rem, 4rem);
-  --mobile-width: calc(var(--mobile-height * 2));
-  --width: var(--desktop-width);
+  --desktop-height: 6rem;
+  --tablet-height: ${headerMdFluidFontSize};
+  --mobile-height: ${headerSmFluidFontSize};
   --height: var(--desktop-height);
 
+  @media ${tabletAndUnder} {
+    --height: var(--tablet-height);
+  }
+
   @media ${mobileAndUnder} {
-    --width: var(--mobile-width);
     --height: var(--mobile-height);
   }
 `;

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -81,14 +81,14 @@ export default function Hero() {
         <ArrowButtonWrapper
           initial={{
             opacity: 0,
-            translateY: "50%",
+            translateY: "50px",
           }}
           animate={{
             opacity: 1,
-            translateY: "0%",
+            translateY: "0px",
           }}
           transition={{
-            duration: 0.1,
+            duration: 0.3,
             delay: 1.3,
           }}
         >

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,4 +1,4 @@
-import { laptopAndUnder, mobileAndUnder, tabletAndUnder } from "constant";
+import { mobileAndUnder, tabletAndUnder } from "constant";
 import { motion } from "framer-motion";
 import { useLoadSectionRefAndId } from "hooks/helpers/useLoadSectionRefAndId";
 import NextLink from "next/link";
@@ -159,8 +159,44 @@ const Header = styled(motion.h1)`
   color: var(--white);
   text-align: center;
   z-index: 1;
+  line-height: 115%;
   @media ${tabletAndUnder} {
     font: var(--header-md);
+    line-height: 115%;
+  }
+  @media ${mobileAndUnder} {
+    /* 
+      the formula for this fluid typography is as follows:
+
+      x — current viewport width value (px).
+      y — resulting fluid font size for a current viewport width value x (px).
+      v — viewport width value that affects fluid value change rate (vw).
+      r — relative size equal to browser font size. Default value is 16px.
+
+      to find v:
+
+      v = 100 * (y2-y1) / (x2-x1)
+
+      to find r:
+
+      r = (x1y2 - x2y1) / (x1 - x2)
+
+      and these values are used like so:
+
+      font-size: clamp([min]rem, [v]vw + [r]rem, [max]rem);
+
+      NOTE: the max and min font size values are used in px in the formula, but should be converted to rem when used
+
+      see https://www.smashingmagazine.com/2022/01/modern-fluid-typography-css-clamp/ for reference
+
+      in this case the values used were:
+
+      x1 = 300px
+      x2 = 620px
+      y1 = 40px
+      y2 = 64px
+    */
+    font-size: clamp(2.5rem, 7vw + 1.18rem, 4rem);
   }
 `;
 
@@ -242,25 +278,11 @@ const OOLogoIcon = styled(OOLogo)`
   width: var(--width);
   height: var(--height);
   --desktop-width: 166px;
-  --desktop-height: 83px;
-  --laptop-width: 126px;
-  --laptop-height: 64px;
-  --tablet-width: 116px;
-  --tablet-height: 58px;
-  --mobile-width: 66px;
-  --mobile-height: 36px;
+  --desktop-height: 82px;
+  --mobile-height: clamp(2.5rem, 7vw + 1.18rem, 4rem);
+  --mobile-width: calc(var(--mobile-height * 2));
   --width: var(--desktop-width);
   --height: var(--desktop-height);
-
-  @media ${laptopAndUnder} {
-    --width: var(--laptop-width);
-    --height: var(--laptop-height);
-  }
-
-  @media ${tabletAndUnder} {
-    --width: var(--tablet-width);
-    --height: var(--tablet-height);
-  }
 
   @media ${mobileAndUnder} {
     --width: var(--mobile-width);

--- a/components/Projects.tsx
+++ b/components/Projects.tsx
@@ -148,7 +148,6 @@ const SherlockIcon = styled(SherlockLogo)``;
 
 const OuterWrapper = styled(BaseOuterWrapper)`
   background: var(--white);
-  padding-top: 228px;
   padding-bottom: 128px;
 `;
 

--- a/components/SectionHeader.tsx
+++ b/components/SectionHeader.tsx
@@ -31,10 +31,12 @@ const Header = styled(motion.h2)`
   }
   @media ${tabletAndUnder} {
     --width: var(--width-desktop-tablet);
+    margin-bottom: 64px;
   }
   @media ${mobileAndUnder} {
     --width: var(--width-mobile);
     font: var(--header-sm);
+
     margin-top: 24px;
     margin-bottom: 40px;
   }

--- a/components/SectionHeader.tsx
+++ b/components/SectionHeader.tsx
@@ -1,4 +1,4 @@
-import { laptopAndUnder, mobileAndUnder, tabletAndUnder } from "constant";
+import { headerLgFluid, headerMdFluid, headerSmFluid, laptopAndUnder, mobileAndUnder, tabletAndUnder } from "constant";
 import { motion } from "framer-motion";
 import { useState } from "react";
 import styled, { CSSProperties } from "styled-components";
@@ -26,17 +26,19 @@ const Header = styled(motion.h2)`
   margin-top: 48px;
   margin-bottom: 128px;
   font: var(--header-lg);
+  ${headerLgFluid}
   @media ${laptopAndUnder} {
     --width: var(--width-laptop);
   }
   @media ${tabletAndUnder} {
     --width: var(--width-desktop-tablet);
+    ${headerMdFluid}
     margin-bottom: 64px;
   }
   @media ${mobileAndUnder} {
     --width: var(--width-mobile);
     font: var(--header-sm);
-
+    ${headerSmFluid}
     margin-top: 24px;
     margin-bottom: 40px;
   }

--- a/constant/style/fonts.ts
+++ b/constant/style/fonts.ts
@@ -1,3 +1,5 @@
+import { css } from "styled-components";
+
 const weight = 400;
 
 const family = "'Halyard Display', sans-serif";
@@ -8,6 +10,32 @@ export const headerLg = `${weight} ${96 / 16}rem/112px ${family}`;
 export const headerMd = `${weight} ${64 / 16}rem/72px ${family}`;
 export const headerSm = `${weight} ${40 / 16}rem/55px ${family}`;
 export const headerXs = `${weight} ${32 / 16}rem/45px ${family}`;
+
+export const headerMdFluidFontSize = `
+  clamp(${64 / 16}rem, 6vw + 2rem, ${96 / 16}rem)
+`;
+
+export const headerMdFluidLineHeight = `
+  clamp(72px, 6vw + 2rem, 112px)
+`;
+
+export const headerMdFluid = css`
+  font-size: ${headerMdFluidFontSize};
+  line-height: ${headerMdFluidLineHeight};
+`;
+
+export const headerSmFluidFontSize = `
+  clamp(${40 / 16}rem, 7vw + 1.18rem, ${64 / 16}rem)
+`;
+
+export const headerSmFluidLineHeight = `
+  clamp(55px, 5vw + 2.5rem, 72px)
+`;
+
+export const headerSmFluid = css`
+  font-size: ${headerSmFluidFontSize};
+  line-height: ${headerSmFluidLineHeight};
+`;
 
 export const bodyXl = `${weight} ${26 / 16}rem/32px ${family}`;
 export const bodyLg = `${weight} ${20 / 16}rem/28px ${family}`;

--- a/constant/style/fonts.ts
+++ b/constant/style/fonts.ts
@@ -1,17 +1,16 @@
-const regular = 400;
+const weight = 400;
 
 const family = "'Halyard Display', sans-serif";
 
-// New fonts
-export const subHeader = `${regular} 16px/19px ${family}`;
-export const subHeaderSm = `${regular} 12px/16px ${family}`;
-export const headerLg = `${regular} 96px/112px ${family}`;
-export const headerMd = `${regular} 64px/72px ${family}`;
-export const headerSm = `${regular} 40px/55px ${family}`;
-export const headerXs = `${regular} 32px/45px ${family}`;
+export const subHeader = `${weight} 16px/19px ${family}`;
+export const subHeaderSm = `${weight} 12px/16px ${family}`;
+export const headerLg = `${weight} 96px/112px ${family}`;
+export const headerMd = `${weight} 64px/72px ${family}`;
+export const headerSm = `${weight} 40px/55px ${family}`;
+export const headerXs = `${weight} 32px/45px ${family}`;
 
-export const bodyXl = `${regular} 26px/32px ${family}`;
-export const bodyLg = `${regular} 20px/28px ${family}`;
-export const bodyMd = `${regular} 18px/24px ${family}`;
-export const bodySm = `${regular} 16px/22px ${family}`;
-export const bodyXs = `${regular} 12px/17px ${family}`;
+export const bodyXl = `${weight} 26px/32px ${family}`;
+export const bodyLg = `${weight} 20px/28px ${family}`;
+export const bodyMd = `${weight} 18px/24px ${family}`;
+export const bodySm = `${weight} 16px/22px ${family}`;
+export const bodyXs = `${weight} 12px/17px ${family}`;

--- a/constant/style/fonts.ts
+++ b/constant/style/fonts.ts
@@ -11,6 +11,19 @@ export const headerMd = `${weight} ${64 / 16}rem/72px ${family}`;
 export const headerSm = `${weight} ${40 / 16}rem/55px ${family}`;
 export const headerXs = `${weight} ${32 / 16}rem/45px ${family}`;
 
+export const headerLgFluidFontSize = `
+  clamp(${64 / 16}rem, 6vw + 2rem, ${96 / 16}rem)
+`;
+
+export const headerLgFluidLineHeight = `
+  clamp(72px, 6vw + 2rem, 112px)
+`;
+
+export const headerLgFluid = css`
+  font-size: ${headerLgFluidFontSize};
+  line-height: ${headerLgFluidLineHeight};
+`;
+
 export const headerMdFluidFontSize = `
   clamp(${64 / 16}rem, 6vw + 2rem, ${96 / 16}rem)
 `;

--- a/constant/style/fonts.ts
+++ b/constant/style/fonts.ts
@@ -2,15 +2,15 @@ const weight = 400;
 
 const family = "'Halyard Display', sans-serif";
 
-export const subHeader = `${weight} 16px/19px ${family}`;
-export const subHeaderSm = `${weight} 12px/16px ${family}`;
-export const headerLg = `${weight} 96px/112px ${family}`;
-export const headerMd = `${weight} 64px/72px ${family}`;
-export const headerSm = `${weight} 40px/55px ${family}`;
-export const headerXs = `${weight} 32px/45px ${family}`;
+export const subHeader = `${weight} ${16 / 16}rem/19px ${family}`;
+export const subHeaderSm = `${weight} ${12 / 16}rem/16px ${family}`;
+export const headerLg = `${weight} ${96 / 16}rem/112px ${family}`;
+export const headerMd = `${weight} ${64 / 16}rem/72px ${family}`;
+export const headerSm = `${weight} ${40 / 16}rem/55px ${family}`;
+export const headerXs = `${weight} ${32 / 16}rem/45px ${family}`;
 
-export const bodyXl = `${weight} 26px/32px ${family}`;
-export const bodyLg = `${weight} 20px/28px ${family}`;
-export const bodyMd = `${weight} 18px/24px ${family}`;
-export const bodySm = `${weight} 16px/22px ${family}`;
-export const bodyXs = `${weight} 12px/17px ${family}`;
+export const bodyXl = `${weight} ${26 / 16}rem/32px ${family}`;
+export const bodyLg = `${weight} ${20 / 16}rem/28px ${family}`;
+export const bodyMd = `${weight} ${18 / 16}rem/24px ${family}`;
+export const bodySm = `${weight} ${16 / 16}rem/22px ${family}`;
+export const bodyXs = `${weight} ${12 / 16}rem/17px ${family}`;

--- a/contexts/ScrollContext.tsx
+++ b/contexts/ScrollContext.tsx
@@ -66,6 +66,7 @@ export function ScrollProvider({ children }: { children: ReactNode }) {
 
       return top < middleOfScreen && bottom > middleOfScreen;
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [scrollY]);
 
   useEffect(() => {
@@ -82,7 +83,7 @@ export function ScrollProvider({ children }: { children: ReactNode }) {
     function hasEnteredColorChangeSection() {
       if (colorChangeSectionRef.current?.offsetTop === undefined) return false;
 
-      return scrollY > colorChangeSectionRef.current.offsetTop - headerBlurHeight;
+      return scrollY > colorChangeSectionRef.current.offsetTop - headerBlurHeight * 1.8;
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [scrollY]);

--- a/hooks/helpers/useLoadSectionRefAndId.ts
+++ b/hooks/helpers/useLoadSectionRefAndId.ts
@@ -8,5 +8,6 @@ export function useLoadSectionRefAndId(ref: RefObject<HTMLDivElement>, id: strin
     if (ref.current) {
       loadSectionRefAndId(id, ref);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ref.current]);
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "usehooks-ts": "^2.9.1"
   },
   "devDependencies": {
-    "@tanstack/react-query-devtools": "^4.19.1",
     "@babel/core": "^7.20.5",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-react": "^7.18.6",


### PR DESCRIPTION
### Motivation

I want the header sizes to scale fluidly with the viewport, so that they look proportional on all screen sizes.

### Changes

* Use `clamp` for small and medium headers to make them fluid
*  Tie the size of the OO icon to the size of the font