### PR TITLE
fix: navbar does not work on initial load

### DIFF
--- a/components/SupportSection.tsx
+++ b/components/SupportSection.tsx
@@ -1,4 +1,5 @@
 import { mobileAndUnder, tabletAndUnder } from "constant";
+import { useInView } from "framer-motion";
 import { useLoadSectionRefAndId } from "hooks/helpers/useLoadSectionRefAndId";
 import NextLink from "next/link";
 import UpRightArrowLg from "public/assets/up-right-arrow-lg.svg";
@@ -9,14 +10,19 @@ import { BaseOuterWrapper } from "./Wrappers";
 export default function SupportSection() {
   const id = "support";
   const ref = useRef<HTMLDivElement>(null);
+  const inView = useInView(ref, { amount: "some" });
   useLoadSectionRefAndId(ref, id);
 
   return (
     <OuterWrapper id={id} ref={ref}>
       <Background>
         <Video autoPlay loop muted playsInline>
-          <source src="/assets/uma.xyz.mp4" type="video/mp4" />
-          <source src="/assets/uma.xyz.webm" type="video/webm" />
+          {inView && (
+            <>
+              <source src="/assets/uma.xyz.mp4" type="video/mp4" />
+              <source src="/assets/uma.xyz.webm" type="video/webm" />
+            </>
+          )}
         </Video>
         <RearOverlay />
         <FrontOverlay />

--- a/components/pages/Home.tsx
+++ b/components/pages/Home.tsx
@@ -1,7 +1,5 @@
 import { Layout } from "components/Layout";
-import { useInView } from "framer-motion";
 import dynamic from "next/dynamic";
-import { useEffect, useRef, useState } from "react";
 
 const Hero = dynamic(() => import("components/Hero"));
 const HowItWorks = dynamic(() => import("components/HowItWorks"));
@@ -12,31 +10,15 @@ const SupportSection = dynamic(() => import("components/SupportSection"));
 const Footer = dynamic(() => import("components/Footer"));
 
 export function Home() {
-  const howItWorksWrapperRef = useRef<HTMLDivElement>(null);
-  const howItWorksInView = useInView(howItWorksWrapperRef, { amount: 0.1 });
-  const [loadRestOfPage, setLoadRestOfPage] = useState(false);
-
-  useEffect(() => {
-    if (howItWorksInView) {
-      setLoadRestOfPage(true);
-    }
-  }, [howItWorksInView]);
-
   return (
     <Layout>
       <Hero />
-      <div ref={howItWorksWrapperRef}>
-        <HowItWorks />
-      </div>
-      {loadRestOfPage && (
-        <>
-          <VoteParticipation />
-          <Builder />
-          <Projects />
-          <SupportSection />
-          <Footer />
-        </>
-      )}
+      <HowItWorks />
+      <VoteParticipation />
+      <Builder />
+      <Projects />
+      <SupportSection />
+      <Footer />
     </Layout>
   );
 }


### PR DESCRIPTION
### Motivation

Make the whole site available on initial load. This makes our lighthouse slightly worse, but it's not worth the compromise.

### Changes

* Remove lazy loading of site sections
* Lazy load video since its part of the initial load now