### PR TITLE
fix: vote countdown, change to utc

### DIFF
--- a/components/VoteTicker.tsx
+++ b/components/VoteTicker.tsx
@@ -28,7 +28,7 @@ export default function VoteTicker({ isLightTheme = false }) {
 
   function getMillisecondsUntilMidnight() {
     const now = new Date();
-    const midnight = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
+    const midnight = new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate() + 1));
     return midnight.getTime() - now.getTime();
   }
 


### PR DESCRIPTION
## motivation
vote countdown differs from voter dapp

## changes
we need to use utc time to figure out midnight, rather than local time