### PR TITLE
fix: use utc time when fetching date, time

### DIFF
--- a/components/VoteTicker.tsx
+++ b/components/VoteTicker.tsx
@@ -28,7 +28,7 @@ export default function VoteTicker({ isLightTheme = false }) {
 
   function getMillisecondsUntilMidnight() {
     const now = new Date();
-    const midnight = new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate() + 1));
+    const midnight = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1));
     return midnight.getTime() - now.getTime();
   }
 
@@ -37,7 +37,9 @@ export default function VoteTicker({ isLightTheme = false }) {
     const seconds = Math.floor(milliseconds / 1000);
     const minutes = Math.floor(seconds / 60);
     const hours = Math.floor(minutes / 60);
-    return `${hours}:${minutes % 60}:${seconds % 60}`;
+    return `${hours.toString().padStart(2, "0")}:${(minutes % 60).toString().padStart(2, "0")}:${(seconds % 60)
+      .toString()
+      .padStart(2, "0")}`;
   }
 
   useInterval(() => {


### PR DESCRIPTION
## motivation
some people were seeing negative time before the vote

## changes
could not find the real cause of this, but most likely due to using local time to seed the utc midnight time, this might sometimes put the day before or after the current utc day, but just a guess