### PR TITLE
improve: mobile tweaks

### DIFF
--- a/src/components/AnimatedLink.tsx
+++ b/src/components/AnimatedLink.tsx
@@ -3,17 +3,27 @@ import NextLink from "next/link";
 import UpRightArrow from "public/assets/up-right-arrow.svg";
 import { ReactNode } from "react";
 
-export default function AnimatedLink({ href, children }: { href: string; children: ReactNode }) {
+export default function AnimatedLink({
+  href,
+  children,
+  asATag = false,
+}: {
+  href: string;
+  children: ReactNode;
+  asATag?: boolean;
+}) {
+  const Link = asATag ? "a" : NextLink;
   return (
-    <NextLink
+    <Link
       className="group flex items-baseline text-xl text-red transition duration-300 hover:text-grey-900"
       href={href}
+      scroll={false}
       target={isExternalLink(href) ? "_blank" : undefined}
     >
       {children}
       <div className="relative left-0 ml-4 inline-flex h-8 w-8 items-center justify-center rounded-lg border border-red transition-all duration-300 group-hover:ml-3 group-hover:border-grey-900 group-hover:bg-grey-900">
         <UpRightArrow className="[&_path]:transition-[stroke] [&_path]:duration-300 [&_path]:group-hover:stroke-white" />
       </div>
-    </NextLink>
+    </Link>
   );
 }

--- a/src/components/AnimatedLink.tsx
+++ b/src/components/AnimatedLink.tsx
@@ -17,7 +17,6 @@ export default function AnimatedLink({
     <Link
       className="group flex items-baseline text-xl text-red transition duration-300 hover:text-grey-900"
       href={href}
-      scroll={false}
       target={isExternalLink(href) ? "_blank" : undefined}
     >
       {children}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -26,7 +26,7 @@ export default function Footer() {
         <VoteTicker isLightTheme />
       </div>
       <div className="mx-auto flex w-full max-w-[--page-width] flex-col-reverse pt-12 md:grid md:grid-cols-[1fr_1fr]">
-        <div className="row-start-2 my-14 grid h-fit grid-rows-3 justify-center justify-items-start md:row-start-auto md:h-auto md:grid-rows-none md:justify-normal xl:grid-cols-3 xl:grid-rows-none">
+        <div className="row-start-2 my-14 grid h-fit grid-rows-2 justify-center justify-items-start md:row-start-auto md:h-auto md:grid-rows-none md:justify-normal xl:grid-cols-3 xl:grid-rows-none">
           <NextLink className="hidden md:mb-4 md:block" href="#">
             <UmaLogo className="[&>*]:fill-red" />
           </NextLink>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { heroVideoBackground, homePageLinks, osnapPageLinks, white } from "@/constant";
+import { homePageLinks, osnapPageLinks, white } from "@/constant";
 import { useScrollContext } from "@/hooks/contexts/useScrollContext";
 import { motion } from "framer-motion";
 import { usePathname } from "next/navigation";
@@ -26,7 +26,7 @@ export default function Header() {
       transition={{ duration: 0.2, delay: 0.7 }}
       style={
         {
-          "--background": isLightTheme ? white : heroVideoBackground,
+          "--background": isLightTheme ? white : "var(--hero-video-background)",
         } as CSSProperties
       }
       className="sticky top-0 z-[2] grid h-[--header-height] items-center bg-[--background] px-[--page-padding] pt-4 shadow-[0px_24px_24px_24px_var(--background)] backdrop-blur-sm"

--- a/src/components/Header/MobileMenu.tsx
+++ b/src/components/Header/MobileMenu.tsx
@@ -1,4 +1,4 @@
-import { grey500, heroVideoBackground, socialLinks, white } from "@/constant";
+import { grey500, socialLinks, white } from "@/constant";
 import { useScrollContext } from "@/hooks/contexts/useScrollContext";
 import { isExternalLink } from "@/utils";
 import NextLink from "next/link";
@@ -35,7 +35,7 @@ export default function MobileMenu({ show, hide, isLightTheme, links }: Props) {
       style={
         {
           "--height": `calc(100dvh - ${scrollY === 0 && isHomePage ? "124px" : "44px"})`,
-          "--background": isLightTheme ? white : heroVideoBackground,
+          "--background": isLightTheme ? white : "var(--hero-video-background)",
           "--opacity": show ? 1 : 0,
           "--link-color": isLightTheme ? grey500 : white,
           pointerEvents: show ? "auto" : "none",

--- a/src/components/Home/Hero.tsx
+++ b/src/components/Home/Hero.tsx
@@ -16,7 +16,7 @@ export default function Hero() {
     if (typeof window === "undefined") return;
     const platform = window.navigator.platform;
     const root = document.documentElement;
-    if (platform === "iPhone" || platform === "iPad") {
+    if (platform === "iPhone" || platform === "iPad" || platform === "Android") {
       root.style.setProperty("--hero-video-background", heroVideoBackgroundIphone);
     }
     if (platform === "Win32") {

--- a/src/components/Home/Hero.tsx
+++ b/src/components/Home/Hero.tsx
@@ -1,15 +1,25 @@
+import { heroVideoBackgroundIphone } from "@/constant";
 import { useLoadSectionRefAndId } from "@/hooks/helpers/useLoadSectionRefAndId";
 import { LazyMotion, m } from "framer-motion";
 import NextLink from "next/link";
 import DownArrow from "public/assets/down-arrow.svg";
 import OOLogo from "public/assets/oo-logo.svg";
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 
 const loadFeatures = () => import("../../utils/features").then((res) => res.default);
 
 export default function Hero() {
   const ref = useRef<HTMLDivElement>(null);
   useLoadSectionRefAndId(ref, "");
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const platform = window.navigator.platform;
+    if (platform === "iPhone" || platform === "iPad") {
+      const root = document.documentElement;
+      root.style.setProperty("--hero-video-background", heroVideoBackgroundIphone);
+    }
+  }, []);
 
   const headerAnimation = {
     initial: {
@@ -44,7 +54,7 @@ export default function Hero() {
   return (
     <LazyMotion features={loadFeatures}>
       <section
-        className="relative grid w-full place-items-center overflow-clip bg-hero-video-background px-[--page-padding]"
+        className="relative grid w-full place-items-center overflow-clip bg-[--hero-video-background] px-[--page-padding]"
         style={{
           height: "calc(100svh - var(--header-height) - var(--vote-ticker-height))",
         }}
@@ -62,6 +72,11 @@ export default function Hero() {
             loop
             muted
             playsInline
+            style={{
+              WebkitMaskImage: "-webkit-radial-gradient(white, black)",
+              WebkitBackfaceVisibility: "hidden",
+              MozBackfaceVisibility: "hidden",
+            }}
           >
             <source src="/assets/hero.mp4" type="video/mp4" />
             <source src="/assets/hero.webm" type="video/webm" />
@@ -109,7 +124,7 @@ export default function Hero() {
             }}
           >
             <NextLink
-              className="opacity-1 isolate flex h-12 w-12 items-center justify-center gap-2 rounded-lg border border-solid border-red bg-hero-video-background p-2 transition duration-300 hover:bg-red-510-opacity-15 hover:shadow-[0px_0px_50px_0px_var(--red)]"
+              className="opacity-1 isolate flex h-12 w-12 items-center justify-center gap-2 rounded-lg border border-solid border-red bg-[--hero-video-background] p-2 transition duration-300 hover:bg-red-510-opacity-15 hover:shadow-[0px_0px_50px_0px_var(--red)]"
               href="#how-it-works"
               aria-label="Go to next section"
             >

--- a/src/components/Home/Hero.tsx
+++ b/src/components/Home/Hero.tsx
@@ -1,4 +1,4 @@
-import { heroVideoBackgroundIphone } from "@/constant";
+import { heroVideoBackgroundIphone, heroVideoBackgroundWindows } from "@/constant";
 import { useLoadSectionRefAndId } from "@/hooks/helpers/useLoadSectionRefAndId";
 import { LazyMotion, m } from "framer-motion";
 import NextLink from "next/link";
@@ -15,9 +15,12 @@ export default function Hero() {
   useEffect(() => {
     if (typeof window === "undefined") return;
     const platform = window.navigator.platform;
+    const root = document.documentElement;
     if (platform === "iPhone" || platform === "iPad") {
-      const root = document.documentElement;
       root.style.setProperty("--hero-video-background", heroVideoBackgroundIphone);
+    }
+    if (platform === "Win32") {
+      root.style.setProperty("--hero-video-background", heroVideoBackgroundWindows);
     }
   }, []);
 

--- a/src/components/Home/Hero.tsx
+++ b/src/components/Home/Hero.tsx
@@ -46,7 +46,7 @@ export default function Hero() {
       <section
         className="relative grid w-full place-items-center overflow-clip bg-hero-video-background px-[--page-padding]"
         style={{
-          height: "calc(100dvh - var(--header-height) - var(--vote-ticker-height))",
+          height: "calc(100svh - var(--header-height) - var(--vote-ticker-height))",
         }}
         ref={ref}
       >

--- a/src/components/Home/Osnap.tsx
+++ b/src/components/Home/Osnap.tsx
@@ -53,7 +53,9 @@ export function Osnap() {
             </div>
           </div>
           <div className="mx-auto w-fit">
-            <AnimatedLink href="/osnap">Learn more about oSnap</AnimatedLink>
+            <AnimatedLink href="/osnap" asATag>
+              Learn more about oSnap
+            </AnimatedLink>
           </div>
         </div>
       </div>

--- a/src/components/Home/Osnap.tsx
+++ b/src/components/Home/Osnap.tsx
@@ -52,7 +52,7 @@ export function Osnap() {
               </p>
             </div>
           </div>
-          <div className="mx-auto w-fit">
+          <div className="mr-auto w-fit sm:mx-auto">
             <AnimatedLink href="/osnap" asATag>
               Learn more about oSnap
             </AnimatedLink>

--- a/src/components/Home/Projects.tsx
+++ b/src/components/Home/Projects.tsx
@@ -117,7 +117,7 @@ function ProjectRow({ projects, line }: { projects: Project[]; line: "top" | "mi
             <div className="w-[25%] transition duration-300 group-hover:-translate-y-3 [&_path]:fill-grey-900 [&_path]:transition [&_path]:duration-300 [&_path]:group-hover:fill-red">
               <Icon />
             </div>
-            <h4 className="absolute -bottom-[40px] mx-auto uppercase text-red opacity-0 transition duration-300 group-hover:-translate-y-3 group-hover:opacity-100">
+            <h4 className="absolute -bottom-[40px] uppercase text-red opacity-0 transition duration-300 group-hover:-translate-y-3 group-hover:opacity-100">
               {name}
             </h4>
           </div>

--- a/src/components/Home/SupportSection.tsx
+++ b/src/components/Home/SupportSection.tsx
@@ -8,11 +8,11 @@ export default function SupportSection() {
 
   return (
     <section
-      className="relative bg-[linear-gradient(180deg,#ffffff_0%,#f9f9f9_100%)] px-[--page-padding] pb-6"
+      className="relative isolate bg-[linear-gradient(180deg,#ffffff_0%,#f9f9f9_100%)] px-[--page-padding] pb-6"
       id={id}
       ref={ref}
     >
-      <div className="isolate">
+      <div>
         <video
           className="pointer-events-none absolute right-0 top-0 h-full w-full object-cover mix-blend-luminosity"
           autoPlay

--- a/src/components/Home/VoteParticipation.tsx
+++ b/src/components/Home/VoteParticipation.tsx
@@ -67,7 +67,11 @@ export default function VoteParticipation() {
   ];
 
   return (
-    <section className="bg-white px-[--page-padding] py-[--header-blur-height]" ref={ref} id={id}>
+    <section
+      className="bg-white px-[--page-padding] pb-8 pt-[--header-blur-height] md:pb-12 lg:pb-16"
+      ref={ref}
+      id={id}
+    >
       <div className="mx-auto max-w-[--page-width]">
         <SectionHeader
           title={

--- a/src/components/Osnap/Hero.tsx
+++ b/src/components/Osnap/Hero.tsx
@@ -5,7 +5,7 @@ import OsnapLogo from "public/assets/osnap-logo.svg";
 
 export function Hero() {
   return (
-    <section className="mx-auto -mt-[calc(var(--header-height)+var(--vote-ticker-height))] max-w-[480px] bg-white px-6 pt-[200px] md:max-w-[1216px] lg:min-h-[100dvh]">
+    <section className="mx-auto -mt-[calc(var(--header-height)+var(--vote-ticker-height))] max-w-[480px] bg-white px-6 pt-[200px] md:max-w-[1216px] lg:min-h-[100svh]">
       <div className="relative isolate mb-8 md:grid md:grid-cols-[1.4fr,1fr] md:gap-4">
         <div className="absolute -right-[30px] -top-[7px] -z-10 w-[109px] -rotate-[27deg] rounded-2xl md:hidden">
           <Image src={handshake} alt="handshake" className=" rounded-xl" priority />

--- a/src/components/VoteTicker.tsx
+++ b/src/components/VoteTicker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { grey200, grey400, grey500, grey700, grey900, heroVideoBackground, red, white } from "@/constant";
+import { grey200, grey400, grey500, grey700, grey900, red, white } from "@/constant";
 import { useVotingInfo } from "@/hooks";
 import { motion } from "framer-motion";
 import NextLink from "next/link";
@@ -45,7 +45,7 @@ export default function VoteTicker({ isLightTheme: isLightTheme_ = false }) {
       transition={{ duration: 0.3, delay: 0.8 }}
       style={
         {
-          "--background": isLightTheme ? "transparent" : heroVideoBackground,
+          "--background": isLightTheme ? "transparent" : "var(--hero-video-background)",
           "--color": isLightTheme ? grey900 : grey500,
         } as CSSProperties
       }

--- a/src/constant/style/colors.ts
+++ b/src/constant/style/colors.ts
@@ -27,3 +27,4 @@ export const grey950 = "hsla(0, 0%, 8%, 1)";
 export const black = "hsla(0, 0%, 0%, 1)";
 export const heroVideoBackground = "hsl(300, 6%, 15%)";
 export const heroVideoBackgroundIphone = "#232124";
+export const heroVideoBackgroundWindows = "#252125";

--- a/src/constant/style/colors.ts
+++ b/src/constant/style/colors.ts
@@ -25,4 +25,5 @@ export const grey800 = "hsla(285, 4%, 19%, 1)"; // #FDFDFD
 export const grey900 = "hsla(280, 4%, 15%, 1)";
 export const grey950 = "hsla(0, 0%, 8%, 1)";
 export const black = "hsla(0, 0%, 0%, 1)";
-export const heroVideoBackground = "hsl(300,6%,15%)";
+export const heroVideoBackground = "hsl(300, 6%, 15%)";
+export const heroVideoBackgroundIphone = "#232124";

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -176,7 +176,7 @@ body {
   --grey-800: hsla(285, 4%, 19%, 1);
   --grey-900: hsla(280, 4%, 15%, 1);
   --grey-950: hsla(0, 0%, 8%, 1);
-  --hero-video-background: hsl(300,6%,15%);
+  --hero-video-background: #292429;
   /* fonts */
   --header-lg: 400 6rem/112px "Halyard Display", sans-serif;
   --header-md: 400 4rem/72px "Halyard Display", sans-serif;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -15,7 +15,6 @@ import {
   grey800,
   grey900,
   grey950,
-  heroVideoBackground,
   red,
   red510Opacity15,
   red550,
@@ -59,7 +58,6 @@ module.exports = {
       white: white,
       "white-200": white200,
       "white-opacity-10": whiteOpacity10,
-      "hero-video-background": heroVideoBackground,
     },
     extend: {
       fontSize: {


### PR DESCRIPTION
fix a couple of issues on mobile:

1. fix the video background not matching in the home page hero on iphones (very hacky but hey it finally works)
2. fix a bug where clicking the "learn more about osnap" link would take you to the footer if the osnap screen
3. use svh instead of dvh to prevent resizing of the section on scroll
4. fix some alignment and padding issues on small screens
5. fix wrong number of grid rows in footer links on small screens