### PR TITLE
improve: faqs layout

### DIFF
--- a/src/components/Osnap/Faq.tsx
+++ b/src/components/Osnap/Faq.tsx
@@ -1,49 +1,45 @@
 import Link from "next/link";
 
 export function Faq() {
+  const faqs = [
+    {
+      question: "How does UMA secure the governance process?",
+      answer:
+        "oSnap proposes successful governance votes to UMA, along with a bond. Anyone can dispute statements submitted to UMA by posting their own bond. This will trigger a vote, and if the dispute is successful, they will claim half the proposer's bond.",
+    },
+    {
+      question: "What's the difference between the voting period and the challenge period?",
+      answer:
+        "During the voting period members of your community are able to vote on the proposal in Snapshot. During the challenge period UMA token holders are able to dispute false proposals in exchange for claiming their bonds.",
+    },
+    {
+      question: "What happens if Snapshot is compromised?",
+      answer:
+        "UMA's oracle design ensures that false or malicious proposals not based on successful governance votes will be disputed and will not execute.",
+    },
+    {
+      question: "What chains does oSnap support?",
+      answer: (
+        <>
+          Since oSnap uses UMA as its oracle, it supports the same chains as UMA. See them all{" "}
+          <Link className="text-red underline" href="https://docs.uma.xyz/resources/network-addresses" target="_blank">
+            here.
+          </Link>
+        </>
+      ),
+    },
+  ];
   return (
-    <section className="bg-grey-25 px-4 py-8 md:px-6 lg:px-8">
-      <div className="mx-auto max-w-[400px] md:max-w-[1216px]">
+    <section className="bg-grey-25 px-4 py-8 sm:px-6 lg:px-8">
+      <div className="md:max-w-[1216px]">
         <h2 className="mb-12 text-3xl text-grey-900 md:text-6xl">FAQs</h2>
         <div className="mb-12 grid grid-cols-[repeat(auto-fill,minmax(min(300px,100%),1fr))] gap-x-8 gap-y-10 lg:gap-y-16">
-          <div className="max-w-[min(400px,100%)]">
-            <h3 className="mb-2 text-lg text-grey-900">How does UMA secure the governance process?</h3>
-            <p className=" text-grey-600">
-              oSnap proposes successful governance votes to UMA, along with a bond. Anyone can dispute statements
-              submitted to UMA by posting their own bond. This will trigger a vote, and if the dispute is successful,
-              they will claim half the proposer&apos;s bond.
-            </p>
-          </div>
-          <div className="max-w-[min(400px,100%)]">
-            <h3 className="mb-2 text-lg text-grey-900">
-              What&apos;s the difference between the voting period and the challenge period?
-            </h3>
-            <p className="text-grey-600">
-              During the voting period members of your community are able to vote on the proposal in Snapshot. During
-              the challenge period UMA token holders are able to dispute false proposals in exchange for claiming their
-              bonds.
-            </p>
-          </div>
-          <div className="max-w-[min(400px,100%)]">
-            <h3 className="mb-2 text-lg text-grey-900">What happens if Snapshot is compromised?</h3>
-            <p className="text-grey-600">
-              UMA&apos;s oracle design ensures that false or malicious proposals not based on successful governance
-              votes will be disputed and will not execute.
-            </p>
-          </div>
-          <div className="max-w-[min(400px,100%)]">
-            <h3 className="mb-2 text-lg text-grey-900">What chains does oSnap support?</h3>
-            <p className="text-grey-600">
-              Since oSnap uses UMA as its oracle, it supports the same chains as UMA. See them all{" "}
-              <Link
-                className="text-red underline"
-                href="https://docs.uma.xyz/resources/network-addresses"
-                target="_blank"
-              >
-                here.
-              </Link>
-            </p>
-          </div>
+          {faqs.map(({ question, answer }) => (
+            <div>
+              <h3 className="mb-2 text-lg text-grey-900">{question}</h3>
+              <p className=" text-grey-600">{answer}</p>
+            </div>
+          ))}
         </div>
         <div className="flex flex-col gap-6 rounded-2xl bg-grey-100 px-5 py-8 md:flex-row md:items-center md:justify-between md:px-8">
           <div>

--- a/src/components/Osnap/Faq.tsx
+++ b/src/components/Osnap/Faq.tsx
@@ -41,7 +41,7 @@ export function Faq() {
             </div>
           ))}
         </div>
-        <div className="flex flex-col gap-6 rounded-2xl bg-grey-100 px-5 py-8 md:flex-row md:items-center md:justify-between md:px-8">
+        <div className="max-w-[--page-width] mx-auto flex flex-col gap-6 rounded-2xl bg-grey-100 px-5 py-8 md:flex-row md:items-center md:justify-between md:px-8">
           <div>
             <h3 className="mb-2 text-lg text-grey-900">Want to know more?</h3>
             <p className="text-grey-600">Let&apos;s book a call and talk about what oSnap can do for you.</p>

--- a/src/components/Osnap/Faq.tsx
+++ b/src/components/Osnap/Faq.tsx
@@ -31,7 +31,7 @@ export function Faq() {
   ];
   return (
     <section className="bg-grey-25 px-4 py-8 sm:px-6 lg:px-8">
-      <div className="md:max-w-[1216px]">
+      <div className="md:max-w-[1216px] md:mx-auto">
         <h2 className="mb-12 text-3xl text-grey-900 md:text-6xl">FAQs</h2>
         <div className="mb-12 grid grid-cols-[repeat(auto-fill,minmax(min(300px,100%),1fr))] gap-x-8 gap-y-10 lg:gap-y-16">
           {faqs.map(({ question, answer }) => (


### PR DESCRIPTION
The layout of the FAQs section on the osnap page was a bit wonky at tablet screen sizes. 

Simplify how the layout works so that it shifts to columns earlier and avoids an awkward one column layout that is too narrow for a tablet sized screen.