### PR TITLE
feat: launch prep

### DIFF
--- a/src/app/api/airtable/route.ts
+++ b/src/app/api/airtable/route.ts
@@ -11,6 +11,7 @@ const integrationFieldId = "fldafGL8jvE3toWk8";
 const nameFieldId = "fldX9QMw47XvzSW86";
 const communicationChannelFieldId = "fldjxMaR5DEtF29GC";
 const contactDetailsFieldId = "fldRByHAhU5Wbg9pF";
+const referralFieldId = "fldTzAA92VXb6OiBO";
 const airtableBase = new Airtable({ apiKey }).base(baseId);
 export async function POST(request: Request) {
   const body = (await request.json()) as {
@@ -25,6 +26,7 @@ export async function POST(request: Request) {
     [communicationChannelFieldId]: getAirtableCommunicationChannelName(body.communicationChannel),
     [contactDetailsFieldId]: body.contactDetails,
     [integrationFieldId]: "oSnap",
+    [referralFieldId]: "oSnap Landing Page",
   };
 
   try {

--- a/src/components/Osnap/TryOsnapModal.tsx
+++ b/src/components/Osnap/TryOsnapModal.tsx
@@ -19,7 +19,7 @@ export function useTryOsnapModal() {
   function showModal() {
     const newSearchParams = new URLSearchParams(searchParams ?? "");
     newSearchParams.set("modal", "try-osnap");
-    router.push(`${pathname}/?${newSearchParams.toString()}`);
+    router.push(`${pathname}/?${newSearchParams.toString()}`, { scroll: false });
     modalProps.showModal();
   }
 
@@ -27,7 +27,7 @@ export function useTryOsnapModal() {
     const newSearchParams = new URLSearchParams(searchParams ?? "");
     newSearchParams.delete("modal");
     modalProps.closeModal();
-    router.push(`${pathname}/?${newSearchParams.toString()}`);
+    router.push(`${pathname}/?${newSearchParams.toString()}`, { scroll: false });
   }
   return { ...modalProps, showModal, closeModal };
 }

--- a/src/components/Osnap/TryOsnapModal.tsx
+++ b/src/components/Osnap/TryOsnapModal.tsx
@@ -109,8 +109,7 @@ export function TryOsnapModal(props: Props) {
         <Image
           src={fancyOsnapLogo}
           alt="Fancy Osnap Logo"
-          objectFit="contain"
-          className="absolute -bottom-[30%] left-[50%] h-14 w-14 translate-x-[-50%]"
+          className="absolute -bottom-[30%] left-[50%] h-14 w-14 translate-x-[-50%] object-contain"
         />
       </div>
       <div className="w-[min(80vw,540px)] bg-white p-6">

--- a/src/components/Osnap/TryOsnapModal.tsx
+++ b/src/components/Osnap/TryOsnapModal.tsx
@@ -131,10 +131,10 @@ export function TryOsnapModal(props: Props) {
         />
       </div>
       <div className="w-[min(80vw,540px)] bg-white p-6">
-        <h1 className="mb-4 text-center text-4xl font-medium text-grey-950">We’ll get you set up</h1>
+        <h1 className="mb-4 text-center text-4xl font-medium text-grey-950">Dedicated DAO support</h1>
         <p className="mb-6 text-center text-grey-700">
-          Let us introduce oSnap to you personally and see if it&apos;s a fit for you and your organization. Just fill
-          in the details below and we&apos;ll be in touch.
+          Our DevRel team offers dedicated support to every DAO that integrates oSnap. Complete the form below and
+          we&apos;ll reach out ASAP
         </p>
         <form
           action=""

--- a/src/components/Osnap/TryOsnapModal.tsx
+++ b/src/components/Osnap/TryOsnapModal.tsx
@@ -1,5 +1,6 @@
 import { communicationChannels } from "@/constant";
 import Image from "next/image";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import fancyOsnapLogo from "public/assets/fancy-osnap-logo.png";
 import { useEffect, useState } from "react";
 import { ContactDetailsInput, useContactDetailsInput } from "../ContactDetailsInput";
@@ -11,8 +12,24 @@ import { TextInput, useTextInput } from "../TextInput";
 
 export function useTryOsnapModal() {
   const modalProps = useModal();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const router = useRouter();
 
-  return modalProps;
+  function showModal() {
+    const newSearchParams = new URLSearchParams(searchParams ?? "");
+    newSearchParams.set("modal", "try-osnap");
+    router.push(`${pathname}/?${newSearchParams.toString()}`);
+    modalProps.showModal();
+  }
+
+  function closeModal() {
+    const newSearchParams = new URLSearchParams(searchParams ?? "");
+    newSearchParams.delete("modal");
+    modalProps.closeModal();
+    router.push(`${pathname}/?${newSearchParams.toString()}`);
+  }
+  return { ...modalProps, showModal, closeModal };
 }
 
 type Props = ReturnType<typeof useTryOsnapModal>;
@@ -98,6 +115,7 @@ export function TryOsnapModal(props: Props) {
   return (
     <Modal {...props}>
       <div
+        id="try-osnap-modal"
         className="relative h-16"
         style={{
           backgroundImage: "url(/assets/handshake.png)",

--- a/src/components/OsnapV2/Description.tsx
+++ b/src/components/OsnapV2/Description.tsx
@@ -12,7 +12,7 @@ export function Description() {
         <span className="text-primary-500">More inclusive.</span>
       </h1>
       <p className="mx-auto mb-5 max-w-[724px] text-center text-lg text-grey-600 sm:text-2xl">
-        Add oSnap to your existing Snapshot Space and Safe&#123;wallet&#125; in minutes.
+        Add oSnap to your existing Snapshot Space and Safe&#123;Wallet&#125; in minutes.
       </p>
       <p className="mx-auto mb-7 max-w-[724px] text-center text-lg text-grey-600 sm:text-2xl lg:mb-6">
         Combine the advanced strategies and gasless experience of offchain voting with the speed and security of

--- a/src/components/OsnapV2/Faq.tsx
+++ b/src/components/OsnapV2/Faq.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import * as Accordion from "@radix-ui/react-accordion";
-import Link from "next/link";
+import { TryOsnapModal, useTryOsnapModal } from "../Osnap/TryOsnapModal";
 import { PlusMinus } from "./PlusMinus";
 
 export function Faq() {
+  const modalProps = useTryOsnapModal();
+
   const faqs = [
     {
       question: "How does UMA secure the governance process?",
@@ -25,10 +27,16 @@ export function Faq() {
       question: "What chains does oSnap support?",
       answer: (
         <>
-          Since oSnap uses UMA as its oracle, it supports the same chains as UMA. See them all{" "}
-          <Link className="text-red underline" href="https://docs.uma.xyz/resources/network-addresses" target="_blank">
-            here.
-          </Link>
+          oSnap is live on Arbitrum, Ethereum, Optimism and Polygon. If you want oSnap support on other EVM chains,
+          speak to our{" "}
+          <span
+            className="cursor-pointer text-red underline"
+            onClick={() => {
+              modalProps.showModal();
+            }}
+          >
+            integrations team.
+          </span>
         </>
       ),
     },
@@ -58,7 +66,7 @@ export function Faq() {
                 </Accordion.Trigger>
               </Accordion.Header>
               <Accordion.Content
-                className="data-[state=open]:animate-accordion-slide-down data-[state=closed]:animate-accordion-slide-up overflow-hidden text-grey-600 sm:text-lg"
+                className="overflow-hidden text-grey-600 data-[state=closed]:animate-accordion-slide-up data-[state=open]:animate-accordion-slide-down sm:text-lg"
                 asChild
               >
                 <p>{faq.answer}</p>
@@ -67,6 +75,7 @@ export function Faq() {
           ))}
         </Accordion.Root>
       </div>
+      <TryOsnapModal {...modalProps} />
     </section>
   );
 }

--- a/src/components/OsnapV2/Hero.tsx
+++ b/src/components/OsnapV2/Hero.tsx
@@ -1,11 +1,12 @@
 import Image from "next/image";
 import bgImage from "public/assets/bg-image.png";
 import introducingOsnap from "public/assets/introducing-osnap.png";
+import { InitialLoadTryOsnapModal } from "./InitialLoadTryOsnapModal";
 import { TryOsnapButton } from "./TryOsnapButton";
 export function Hero() {
   return (
     <section className="-mt-[calc(var(--header-height)+var(--vote-ticker-height))] bg-white px-page-padding pb-8 pt-[150px] md:pb-12 lg:pb-[72px] lg:pt-[200px]">
-      <Image src={bgImage} alt="bg image" className="absolute inset-0 h-full w-full -z-10 isolate" layout="fill" />
+      <Image src={bgImage} alt="bg image" className="absolute inset-0 isolate -z-10 h-full w-full" layout="fill" />
       <Image
         src={introducingOsnap}
         alt="introducing oSnap"
@@ -20,6 +21,7 @@ export function Hero() {
         Optimistically execute governance transactions onchain where your community can approve them.
       </p>
       <TryOsnapButton />
+      <InitialLoadTryOsnapModal />
     </section>
   );
 }

--- a/src/components/OsnapV2/InitialLoadTryOsnapModal.tsx
+++ b/src/components/OsnapV2/InitialLoadTryOsnapModal.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { useEffectOnce } from "usehooks-ts";
+import { TryOsnapModal, useTryOsnapModal } from "../Osnap/TryOsnapModal";
+
+export function InitialLoadTryOsnapModal() {
+  const modalProps = useTryOsnapModal();
+  const searchParams = useSearchParams();
+  const hasModalInUrl = searchParams?.get("modal") === "try-osnap";
+
+  useEffectOnce(() => {
+    if (hasModalInUrl) modalProps.showModal();
+  });
+
+  return <TryOsnapModal {...modalProps} />;
+}

--- a/src/components/OsnapV2/Video.tsx
+++ b/src/components/OsnapV2/Video.tsx
@@ -9,7 +9,7 @@ import { Icon } from "../Icon";
 import { TryOsnapButton } from "./TryOsnapButton";
 
 export function Video() {
-  const [videoSrc, setVideoSrc] = useState("https://www.youtube.com/embed/R97GIW5M_r0?controls=0");
+  const [videoSrc, setVideoSrc] = useState("https://www.youtube.com/embed/F7HcuI-oYsY?controls=0");
   const [showThumbnail, setShowThumbnail] = useState(true);
 
   const onClick: MouseEventHandler<HTMLDivElement> = (e) => {

--- a/src/components/OsnapV2/Video.tsx
+++ b/src/components/OsnapV2/Video.tsx
@@ -30,7 +30,7 @@ export function Video() {
               className="group absolute left-0 top-0 z-10 aspect-video w-full cursor-pointer rounded-2xl"
               onClick={onClick}
             >
-              <Image src={handshake} alt="handshake" layout="fill" objectFit="cover" className="rounded-2xl" />
+              <Image src={handshake} alt="handshake" className="h-full w-full rounded-2xl object-cover" />
               <Image
                 src={play}
                 alt="play video"

--- a/src/constant/links.tsx
+++ b/src/constant/links.tsx
@@ -27,7 +27,7 @@ export const osnapPageLinks = [
     href: "/",
   },
   {
-    label: "Try oSnap",
+    label: "Quick Start Guide",
     href: "https://docs.uma.xyz/developers/osnap/osnap-quick-start",
   },
   {


### PR DESCRIPTION
changes:

Add "referral" field to modal form (this value is always the same)
Allow linking to osnap modal by including`?modal=try-osnap` in the url
Update youtube video to use the speendrun video

Text changes:

Header link now says "quick start guide"
Capitalize "W" in Safe{Wallet}
Update chains section of FAQ (the last one) and change the link to open the try osnap modal
Update header and body text of try osnap modal