### PR TITLE
feat: add osnap tvs component

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ Storybook is deployed to [Chromatic](https://chromatic.com) via `yarn chromatic`
 
 ## Environment variables
 
-CHAIN_ID = 1 // (or 5 for goerli)
-NODE_URLS ={"1":"https://mainnet.infura.io/v3/xxx","5":"https://goerli.infura.io/v3/xxx"}
-NEXT_PUBLIC_MAILCHIMP_URL="https://umaproject.us19.list-manage.com/subscribe/post?u={user}&id={id}&f_id={f_id}"
-NEXT_PUBLIC_DEFAULT_APY=30.5
+- CHAIN_ID = 1 // (or 5 for goerli)
+- NODE_URLS ={"1":"<https://mainnet.infura.io/v3/xxx","5":"https://goerli.infura.io/v3/xxx"}>
+- NEXT_PUBLIC_MAILCHIMP_URL="<https://umaproject.us19.list-manage.com/subscribe/post?u={user}&id={id}&f_id={f_id}>"
+- NEXT_PUBLIC_DEFAULT_APY=30.5
+- NEXT_PUBLIC_TVS=83M

--- a/src/components/GradientBorder.tsx
+++ b/src/components/GradientBorder.tsx
@@ -1,0 +1,14 @@
+export type GradientBorderProps = React.ComponentPropsWithoutRef<"div">;
+
+export function GradientBorder({ children, className, ...props }: GradientBorderProps) {
+  return (
+    <div
+      className={`group relative w-fit overflow-hidden rounded-2xl bg-white bg-clip-border p-1 shadow-xl ${className}`}
+      {...props}
+    >
+      {/* this span is the gradient. it is its own element so that we can animate it on hover */}
+      <span className="absolute left-[-50%] top-[-50%] z-0 h-[200%] w-[200%] bg-gradient-to-br from-transparent from-40% via-grey-400 via-50% to-60% transition-transform before:content-[''] group-hover:rotate-180" />
+      <div className="relative overflow-hidden rounded-xl border border-grey-50 bg-white">{children}</div>
+    </div>
+  );
+}

--- a/src/components/GradientBorder.tsx
+++ b/src/components/GradientBorder.tsx
@@ -1,13 +1,19 @@
-export type GradientBorderProps = React.ComponentPropsWithoutRef<"div">;
+export type GradientBorderProps = React.ComponentPropsWithoutRef<"div"> & {
+  hoverEffect?: boolean;
+};
 
-export function GradientBorder({ children, className, ...props }: GradientBorderProps) {
+export function GradientBorder({ children, hoverEffect = false, className, ...props }: GradientBorderProps) {
   return (
     <div
       className={`group relative w-fit overflow-hidden rounded-2xl bg-white bg-clip-border p-1 shadow-xl ${className}`}
       {...props}
     >
       {/* this span is the gradient. it is its own element so that we can animate it on hover */}
-      <span className="absolute left-[-50%] top-[-50%] z-0 h-[200%] w-[200%] bg-gradient-to-br from-transparent from-40% via-grey-400 via-50% to-60% transition-transform before:content-[''] group-hover:rotate-180" />
+      <span
+        className={`absolute left-[-50%] top-[-50%] z-0 h-[200%] w-[200%] bg-gradient-to-br from-transparent from-40% via-grey-400 via-50% to-60% transition-transform before:content-[''] ${
+          hoverEffect && "group-hover:rotate-180"
+        }`}
+      />
       <div className="relative overflow-hidden rounded-xl border border-grey-50 bg-white">{children}</div>
     </div>
   );

--- a/src/components/OsnapV2/Hero.tsx
+++ b/src/components/OsnapV2/Hero.tsx
@@ -2,7 +2,7 @@ import Image from "next/image";
 import bgImage from "public/assets/bg-image.png";
 import { InitialLoadTryOsnapModal } from "./InitialLoadTryOsnapModal";
 import { TryOsnapButton } from "./TryOsnapButton";
-import { TvsChip } from "./TvsChip";
+import { TvsChip } from "@/components/OsnapV2/TvsChip";
 import { totalValueSecured } from "@/constant";
 
 export function Hero() {

--- a/src/components/OsnapV2/Hero.tsx
+++ b/src/components/OsnapV2/Hero.tsx
@@ -1,17 +1,14 @@
 import Image from "next/image";
 import bgImage from "public/assets/bg-image.png";
-import introducingOsnap from "public/assets/introducing-osnap.png";
 import { InitialLoadTryOsnapModal } from "./InitialLoadTryOsnapModal";
 import { TryOsnapButton } from "./TryOsnapButton";
+import { TvsChip } from "./TvsChip";
+
 export function Hero() {
   return (
     <section className="-mt-[calc(var(--header-height)+var(--vote-ticker-height))] bg-white px-page-padding pb-8 pt-[150px] md:pb-12 lg:pb-[72px] lg:pt-[200px]">
       <Image src={bgImage} alt="bg image" className="absolute inset-0 isolate -z-10 h-full w-full" layout="fill" />
-      <Image
-        src={introducingOsnap}
-        alt="introducing oSnap"
-        className="mx-auto aspect-[3183/1000] w-[212px] md:mb-1 md:w-[246px]"
-      />
+      <TvsChip amountInMillion={83} className="mx-auto" />
       <h1 className="mb-3 bg-gradient-to-r from-grey-900 to-grey-900/60 bg-clip-text text-center text-4xl font-medium text-transparent sm:text-5xl md:mb-4 md:text-6xl lg:text-7xl">
         Offchain governance.
         <br />

--- a/src/components/OsnapV2/Hero.tsx
+++ b/src/components/OsnapV2/Hero.tsx
@@ -3,13 +3,14 @@ import bgImage from "public/assets/bg-image.png";
 import { InitialLoadTryOsnapModal } from "./InitialLoadTryOsnapModal";
 import { TryOsnapButton } from "./TryOsnapButton";
 import { TvsChip } from "./TvsChip";
+import { totalValueSecured } from "@/constant";
 
 export function Hero() {
   return (
     <section className="-mt-[calc(var(--header-height)+var(--vote-ticker-height))] bg-white px-page-padding pb-8 pt-[150px] md:pb-12 lg:pb-[72px] lg:pt-[200px]">
       <Image src={bgImage} alt="bg image" className="absolute inset-0 isolate -z-10 h-full w-full" layout="fill" />
-      <TvsChip amountInMillion={83} className="mx-auto" />
-      <h1 className="mb-3 bg-gradient-to-r from-grey-900 to-grey-900/60 bg-clip-text text-center text-4xl font-medium text-transparent sm:text-5xl md:mb-4 md:text-6xl lg:text-7xl">
+      <TvsChip amount={totalValueSecured} className="mx-auto" />
+      <h1 className="mb-3 mt-6 bg-gradient-to-r from-grey-900 to-grey-900/60 bg-clip-text text-center text-4xl font-medium text-transparent sm:text-5xl md:mb-4 md:text-6xl lg:text-7xl">
         Offchain governance.
         <br />
         Onchain execution.

--- a/src/components/OsnapV2/TvsChip.tsx
+++ b/src/components/OsnapV2/TvsChip.tsx
@@ -1,0 +1,16 @@
+import { GradientBorder, GradientBorderProps } from "../GradientBorder";
+
+type TvsChipProps = GradientBorderProps & {
+  amountInMillion: number;
+};
+
+export function TvsChip({ amountInMillion, className, ...props }: TvsChipProps) {
+  return (
+    <GradientBorder className={className} {...props}>
+      <div className="flex items-baseline gap-[0.20em] px-2 py-1 text-lg">
+        <span className="font-bold text-primary-500">+${amountInMillion}M</span>
+        Total Value Secured
+      </div>
+    </GradientBorder>
+  );
+}

--- a/src/components/OsnapV2/TvsChip.tsx
+++ b/src/components/OsnapV2/TvsChip.tsx
@@ -1,4 +1,4 @@
-import { GradientBorder, GradientBorderProps } from "../GradientBorder";
+import { GradientBorder, GradientBorderProps } from "@/components/GradientBorder";
 
 type TvsChipProps = GradientBorderProps & {
   amount: number; // eg. 83_000_000

--- a/src/components/OsnapV2/TvsChip.tsx
+++ b/src/components/OsnapV2/TvsChip.tsx
@@ -8,7 +8,7 @@ export function TvsChip({ amount, className, ...props }: TvsChipProps) {
   const formattedAmount = (amount / 10 ** 6).toLocaleString();
 
   return (
-    <GradientBorder className={className} {...props}>
+    <GradientBorder hoverEffect className={className} {...props}>
       <div className="flex items-baseline gap-[0.20em] px-2 py-1 text-lg lg:text-xl">
         <span className="font-bold text-primary-500">+${formattedAmount}M</span>
         Total Value Secured

--- a/src/components/OsnapV2/TvsChip.tsx
+++ b/src/components/OsnapV2/TvsChip.tsx
@@ -1,16 +1,14 @@
 import { GradientBorder, GradientBorderProps } from "@/components/GradientBorder";
 
 type TvsChipProps = GradientBorderProps & {
-  amount: number; // eg. 83_000_000
+  amount: string; // eg. $ 83M
 };
 
 export function TvsChip({ amount, className, ...props }: TvsChipProps) {
-  const formattedAmount = (amount / 10 ** 6).toLocaleString();
-
   return (
     <GradientBorder hoverEffect className={className} {...props}>
       <div className="flex items-baseline gap-[0.20em] px-2 py-1 text-lg lg:text-xl">
-        <span className="font-bold text-primary-500">+${formattedAmount}M</span>
+        <span className="font-bold text-primary-500">${amount}+</span>
         Total Value Secured
       </div>
     </GradientBorder>

--- a/src/components/OsnapV2/TvsChip.tsx
+++ b/src/components/OsnapV2/TvsChip.tsx
@@ -1,14 +1,16 @@
 import { GradientBorder, GradientBorderProps } from "../GradientBorder";
 
 type TvsChipProps = GradientBorderProps & {
-  amountInMillion: number;
+  amount: number; // eg. 83_000_000
 };
 
-export function TvsChip({ amountInMillion, className, ...props }: TvsChipProps) {
+export function TvsChip({ amount, className, ...props }: TvsChipProps) {
+  const formattedAmount = (amount / 10 ** 6).toLocaleString();
+
   return (
     <GradientBorder className={className} {...props}>
-      <div className="flex items-baseline gap-[0.20em] px-2 py-1 text-lg">
-        <span className="font-bold text-primary-500">+${amountInMillion}M</span>
+      <div className="flex items-baseline gap-[0.20em] px-2 py-1 text-lg lg:text-xl">
+        <span className="font-bold text-primary-500">+${formattedAmount}M</span>
         Total Value Secured
       </div>
     </GradientBorder>

--- a/src/constant/env.ts
+++ b/src/constant/env.ts
@@ -1,2 +1,3 @@
 export const defaultApr = process.env.NEXT_PUBLIC_DEFAULT_APR ?? "30.1";
 export const overrideApr: string | undefined = process.env.NEXT_PUBLIC_OVERRIDE_APR;
+export const totalValueSecured = parseInt(process.env.NEXT_PUBLIC_TVS ?? "83000000");

--- a/src/constant/env.ts
+++ b/src/constant/env.ts
@@ -1,3 +1,3 @@
 export const defaultApr = process.env.NEXT_PUBLIC_DEFAULT_APR ?? "30.1";
 export const overrideApr: string | undefined = process.env.NEXT_PUBLIC_OVERRIDE_APR;
-export const totalValueSecured = parseInt(process.env.NEXT_PUBLIC_TVS ?? "83000000");
+export const totalValueSecured = process.env.NEXT_PUBLIC_TVS ?? "0";


### PR DESCRIPTION
- Created a wrapper component for the gradient border shown in the TVS Chip in Figma for us to use anywhere. The hover effect is optional and might actually be better suited for interactive components.
- Pulling value from env as NEXT_PUBLIC_TVS.