### PR TITLE
feat: add stats link to dune dash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ yarn-error.log*
 # local env files
 .env*.local
 .env
+*.env.*
 
 # vercel
 .vercel

--- a/src/constant/links.tsx
+++ b/src/constant/links.tsx
@@ -16,6 +16,10 @@ export const homePageLinks = [
     href: "/osnap",
   },
   {
+    label: "Stats",
+    href: "https:/stats.uma.xyz/",
+  },
+  {
     label: "Docs",
     href: "https://docs.uma.xyz/",
   },
@@ -89,8 +93,8 @@ export const footerLinks = {
       href: "https://docs.uma.xyz/",
     },
     {
-      label: "Projects",
-      href: "https://projects.uma.xyz/",
+      label: "Stats",
+      href: "https://stats.uma.xyz/",
     },
   ],
 };


### PR DESCRIPTION
## motivation
we are in the process of deprecating projects.uma.xyz in favor of a separate stats page and separate lsp/emp managment method. 

## changes
add a link to our dune dash for tvs. also updated git ignore to ignore more env files

![image](https://github.com/UMAprotocol/uma.xyz/assets/4429761/d77b00db-9dc6-4622-b513-513eaa350f42)
