### PR TITLE
feat: update copy,  links & some styles

### DIFF
--- a/src/app/oval/page.tsx
+++ b/src/app/oval/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from "next";
 import { CaptureOev, Hero, OevLost, EarnOev, BuildSafer, OevCreation } from "@/components/Oval";
 import { Layout } from "@/components/Layout";
 
-const title = "OVAL";
+const title = "Oval";
 const description = "TODO: get copy for description";
 
 // TODO: assets for OG metadata

--- a/src/components/Header/DesktopHeader.tsx
+++ b/src/components/Header/DesktopHeader.tsx
@@ -16,8 +16,9 @@ export default function DesktopHeader({ isLightTheme, links, activePath }: Props
 
   return (
     <div className="hidden h-full grid-cols-[1fr_auto_1fr] items-center lg:grid">
-      <NextLink href="/" aria-label="Back to top" className="cursor-pointer">
+      <NextLink href="/" aria-label="Back to top" className="flex cursor-pointer items-baseline gap-2">
         <Icon name="uma-logo" className={`h-[16px] w-[63px] ${isLightTheme ? "text-black" : "text-white"}`} />
+        {activePath === "/oval" && <span className="text-gradient-oval align-bottom text-[16px] leading-4">Oval</span>}
       </NextLink>
       <div className="grid grid-flow-col items-center gap-5">
         {links.map(({ label, href }) => (

--- a/src/components/Header/MobileHeader.tsx
+++ b/src/components/Header/MobileHeader.tsx
@@ -10,9 +10,10 @@ type Props = {
   isLightTheme: boolean;
   menuBg: string;
   links: { label: string; href: string }[];
+  activePath: string | undefined;
 };
 
-export default function MobileHeader({ isLightTheme, menuBg, links }: Props) {
+export default function MobileHeader({ isLightTheme, menuBg, activePath, links }: Props) {
   const [showMenu, setShowMenu] = useState(false);
 
   const closeMenuBarTransition = `
@@ -71,8 +72,10 @@ export default function MobileHeader({ isLightTheme, menuBg, links }: Props) {
           }}
         />
       </button>
-      <NextLink href="/" aria-label="Back to page top">
+
+      <NextLink href="/" aria-label="Back to page top" className="flex items-baseline gap-2">
         <Icon name="uma-logo" className={`h-[16px] w-[63px] ${isLightTheme ? "text-black" : "text-white"}`} />
+        {activePath === "/oval" && <span className="text-gradient-oval align-bottom text-[16px] leading-4">Oval</span>}
       </NextLink>
       <div className="justify-self-end">
         <NextLink

--- a/src/components/Oval/BuildSafer.tsx
+++ b/src/components/Oval/BuildSafer.tsx
@@ -25,7 +25,7 @@ export const BuildSafer = ({ className }: BuildSaferProps) => {
             Build safer
           </h2>
           <p className="text-center text-xl text-[#B3B5B4] xl:text-left">
-            OVAL is not an oracle - it wraps existing oracles.
+            Oval is not an oracle - it wraps existing oracles.
           </p>
           <p className="text-center  text-xl text-[#B3B5B4] xl:text-left">
             Get prices from the oracle you trust most, add others as fallbacks, or take the latest prices from any

--- a/src/components/Oval/CaptureOev.tsx
+++ b/src/components/Oval/CaptureOev.tsx
@@ -4,14 +4,14 @@ import { Divider } from "./Divider";
 const content = [
   "Searcher bots extract Maximal Extractable Value by interfering with Ethereum block production.",
   "Price oracles leave protocols vulnerable to a subset of MEV - called Oracle Extractable Value.",
-  "OVAL wraps your existing price feed, shields you from searchers, and auctions your OEV.",
+  "Oval wraps your existing price feed, shields you from searchers, and auctions your OEV.",
 ];
 
 export const CaptureOev = () => {
   return (
     <section className="relative mx-auto mt-12 flex max-w-[1200px] flex-col items-center gap-4 px-[--page-padding] text-center align-top">
       <h2 className="text-gradient-oval px-[20%] text-center text-sm-fluid md:text-md-fluid lg:text-lg-fluid">
-        Capture OEV with OVAL
+        Capture OEV with Oval
       </h2>
       <h3 className="bg-gradient-to-r from-white to-[hsla(0,0%,72%,1)] bg-clip-text text-center text-xl text-transparent">
         Oracle Value Aggregation Layer

--- a/src/components/Oval/EarnOev.tsx
+++ b/src/components/Oval/EarnOev.tsx
@@ -25,11 +25,11 @@ export const EarnOev = ({ className }: EarnOevProps) => {
             Earn OEV
           </h2>
           <p className="text-center text-xl text-[#B3B5B4] xl:text-left">
-            Legacy oracles leave you vulnerable to MEV searchers. OVAL wraps your existing oracle and shields you from
+            Legacy oracles leave you vulnerable to MEV searchers. Oval wraps your existing oracle and shields you from
             searchers.
           </p>
           <p className="text-center  text-xl text-[#B3B5B4] xl:text-left">
-            OVAL integrates with Flashbots&apos; MEV-Share to auction your OEV, so that you capture the value you
+            Oval integrates with Flashbots&apos; MEV-Share to auction your OEV, so that you capture the value you
             create.
           </p>
           <ExternalLink href="https://docs.uma.xyz/">learn more in docs</ExternalLink>

--- a/src/components/Oval/Hero.tsx
+++ b/src/components/Oval/Hero.tsx
@@ -16,14 +16,14 @@ export const Hero = () => {
       </h1>
       <div className="flex flex-col items-center gap-6 lg:w-[80%] xl:flex-row xl:gap-8">
         <h3 className="px-[20%] text-xl text-[#B3B5B4] xl:px-0">
-          Your protocol creates value when it consumes price updates. Capture this value with OVAL.
+          Your protocol creates value when it consumes price updates. Capture this value with Oval.
         </h3>
         <Link
           className="w-full justify-self-end whitespace-nowrap rounded-lg bg-red px-6 py-4 text-lg text-background no-underline transition hover:opacity-75 xl:w-fit"
           href="https://demo.oval.uma.xyz/"
           target="_blank"
         >
-          Try OVAL today
+          Try Oval today
         </Link>
       </div>
     </section>

--- a/src/components/Oval/Hero.tsx
+++ b/src/components/Oval/Hero.tsx
@@ -11,7 +11,8 @@ export const Hero = () => {
       }}
     >
       <Image priority className="w-[80%]" src={heroImage} alt="decorative hero image" />
-      <h1 className="text-gradient-oval px-[20%] text-center text-sm-fluid  md:text-md-fluid lg:text-lg-fluid">
+
+      <h1 className="text-gradient-oval px-[20%] text-center text-sm-fluid  md:text-md-fluid xl:text-lg-fluid">
         Get paid to use oracles
       </h1>
       <div className="flex flex-col items-center gap-6 lg:w-[80%] xl:flex-row xl:gap-8">
@@ -20,10 +21,10 @@ export const Hero = () => {
         </h3>
         <Link
           className="w-full justify-self-end whitespace-nowrap rounded-lg bg-red px-6 py-4 text-lg text-background no-underline transition hover:opacity-75 xl:w-fit"
-          href="https://demo.oval.uma.xyz/"
+          href="https://docs.uma.xyz/"
           target="_blank"
         >
-          Try Oval today
+          Learn more
         </Link>
       </div>
     </section>

--- a/src/components/Oval/OevCreation.tsx
+++ b/src/components/Oval/OevCreation.tsx
@@ -45,10 +45,10 @@ export const OevCreation = () => {
       </div>
       <Link
         className="w-full justify-self-end whitespace-nowrap rounded-lg bg-red px-6 py-4 text-lg text-background no-underline transition hover:opacity-75 xl:w-fit"
-        href="https://demo.oval.uma.xyz/"
+        href="https://docs.uma.xyz/"
         target="_blank"
       >
-        Try Oval today
+        Learn more
       </Link>
     </section>
   );

--- a/src/components/Oval/OevCreation.tsx
+++ b/src/components/Oval/OevCreation.tsx
@@ -48,7 +48,7 @@ export const OevCreation = () => {
         href="https://demo.oval.uma.xyz/"
         target="_blank"
       >
-        Try OVAL today
+        Try Oval today
       </Link>
     </section>
   );

--- a/src/components/Oval/OevLost.tsx
+++ b/src/components/Oval/OevLost.tsx
@@ -4,6 +4,7 @@ import { useCountUp } from "use-count-up";
 import { oevLost } from "@/constant/env";
 import { Roboto_Mono } from "next/font/google";
 import { useIntersectionObserver } from "usehooks-ts";
+import { Divider } from "./Divider";
 
 // If loading a variable font, you don't need to specify the font weight
 const roboto = Roboto_Mono({
@@ -60,6 +61,7 @@ export const OevLost = () => {
           ${value}
         </div>
       </div>
+      <Divider className="mt-[100px] w-[120px] rotate-90 lg:mt-[150px] lg:w-[200px]" />
     </section>
   );
 };

--- a/src/constant/links.tsx
+++ b/src/constant/links.tsx
@@ -16,7 +16,7 @@ export const homePageLinks = [
     href: "/osnap",
   },
   {
-    label: "OVAL",
+    label: "Oval",
     href: "/oval",
   },
   {
@@ -42,7 +42,7 @@ export const osnapPageLinks = [
 
 export const ovalPageLinks = [
   {
-    label: "OVAL",
+    label: "Oval",
     href: "/oval",
   },
   {


### PR DESCRIPTION
## work done
- change "OVAL" to "Oval"
- change "try oval today" to "learn more", link to docs
- Add "oval" decorative text in header (desktop & mobile)
- Add decorative divider component below oevLost section

<img width="1512" alt="Screenshot 2023-12-15 at 16 14 13" src="https://github.com/UMAprotocol/uma.xyz/assets/51655063/fbaadace-5516-479a-a430-3978a07ab92b">

<img width="1446" alt="Screenshot 2023-12-15 at 16 15 20" src="https://github.com/UMAprotocol/uma.xyz/assets/51655063/6a1c40f1-a9ae-4ebf-857a-21159824defd">
