### PR TITLE
fix: broken dune link

### DIFF
--- a/src/constant/links.tsx
+++ b/src/constant/links.tsx
@@ -17,7 +17,7 @@ export const homePageLinks = [
   },
   {
     label: "Stats",
-    href: "https:/stats.uma.xyz/",
+    href: "https://stats.uma.xyz/",
   },
   {
     label: "Docs",


### PR DESCRIPTION
## motivation

Weirdly, the link `https:/stats.uma.xyz/` (missing "/" after "https:/") resolves to the full URL but only when running the app locally. In production, this returns a 404. 