### PR TITLE
feat: show ellipses in page sections

### DIFF
--- a/src/components/Oval/BuildSafely.tsx
+++ b/src/components/Oval/BuildSafely.tsx
@@ -1,6 +1,7 @@
 import { cn } from "@/utils/styleUtils";
 import { IntegrateOvalButton } from "./IntegrateOvalModal/IntegrateOvalButton";
 import { Animation } from "./Animation";
+import { Ellipse } from "./Ellipsis";
 
 export type BuildSafelyProps = {
   className?: string;
@@ -10,7 +11,7 @@ export const BuildSafely = ({ className }: BuildSafelyProps) => {
   return (
     <section
       className={cn(
-        "relative mx-auto my-[128px] max-w-[1200px] flex-col items-center overflow-clip px-[--page-padding]",
+        "relative mx-auto my-[128px] mt-[200px] max-w-[1200px] flex-col items-center overflow-visible px-[--page-padding]",
         className,
       )}
     >
@@ -20,7 +21,8 @@ export const BuildSafely = ({ className }: BuildSafelyProps) => {
           scene="https://prod.spline.design/cBDg4wVE4edzD-t1/scene.splinecode"
         />
 
-        <div className="flex-3 flex max-w-[500px] flex-col items-center gap-8 xl:items-start">
+        <div className="flex-3 relative flex max-w-[500px] flex-col items-center gap-8 xl:items-start">
+          <Ellipse size="lg" className="left-[-100%] top-0 rotate-[140deg] " />
           <h2 className="text-gradient-oval whitespace-nowrap text-center text-sm-fluid md:text-md-fluid lg:text-lg-fluid xl:text-left">
             Build safely
           </h2>

--- a/src/components/Oval/CaptureOev.tsx
+++ b/src/components/Oval/CaptureOev.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@/utils/styleUtils";
 import { Divider } from "./Divider";
+import { Ellipse } from "./Ellipsis";
 
 const content = [
   "Oracle price updates create a type of MEV called Oracle Extractable Value.",
@@ -10,6 +11,7 @@ const content = [
 export const CaptureOev = () => {
   return (
     <section className="relative mx-auto mt-12 flex max-w-[1200px] flex-col items-center gap-4 px-[--page-padding] text-center align-top">
+      <Ellipse size="lg" className="right-[50%] top-[20%] -rotate-[25deg]" />
       <h2 className="text-gradient-oval px-[10%] text-center text-sm-fluid md:text-md-fluid lg:text-lg-fluid">
         Reclaim Oracle Extractable Value with Oval
       </h2>

--- a/src/components/Oval/Ellipsis.tsx
+++ b/src/components/Oval/Ellipsis.tsx
@@ -2,13 +2,13 @@ import { cn } from "@/utils/styleUtils";
 import { VariantProps, cva } from "class-variance-authority";
 
 const ellipseVariants = cva(
-  "absolute z-0 rounded-[50%] max-w-[1000px] max-h-[400px] bg-gradient-to-br via-transparent from-10% to-80% blur-xl from-transparent to-white/5 ",
+  "absolute z-0 rounded-[50%]  bg-gradient-to-br via-transparent from-10% to-80% blur-xl from-transparent to-white/5 ",
   {
     variants: {
       size: {
-        sm: "w-[60vw] h-[20vw]",
-        md: "w-[100vw] h-[40vw]",
-        lg: "w-[140vw] h-[50vw]",
+        sm: "w-[60vw] h-[20vw] max-w-[600px] max-h-[200px]",
+        md: "w-[100vw] h-[40vw] max-w-[1000px] max-h-[400px]",
+        lg: "w-[140vw] h-[50vw] max-w-[1400px] max-h-[500px]",
       },
     },
     defaultVariants: {

--- a/src/components/Oval/Faq.tsx
+++ b/src/components/Oval/Faq.tsx
@@ -50,7 +50,7 @@ export const Faq = () => {
   return (
     <section
       className={
-        "relative mx-auto mt-12 flex max-w-[700px] flex-col items-center gap-8 px-[--page-padding] text-center align-top xl:max-w-[1300px] xl:gap-[96px]"
+        "relative mx-auto mt-[200px] flex max-w-[700px] flex-col items-center gap-8 px-[--page-padding] text-center align-top xl:max-w-[1300px] xl:gap-[96px]"
       }
     >
       <h2 className="text-gradient-oval px-[10%] text-center text-sm-fluid md:text-md-fluid lg:text-lg-fluid">

--- a/src/components/Oval/Hero.tsx
+++ b/src/components/Oval/Hero.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { Animation } from "./Animation";
+import { Ellipse } from "./Ellipsis";
 
 export const Hero = () => {
   return (
@@ -10,10 +11,12 @@ export const Hero = () => {
       }}
     >
       <Animation className="!h-[400px]" scene="https://prod.spline.design/kqmc4ychq3OeKv5V/scene.splinecode" />
+
       <h1 className="text-gradient-oval px-[20%] text-center text-sm-fluid  md:text-md-fluid xl:text-lg-fluid">
         Get paid to use oracles
       </h1>
-      <div className="flex flex-col items-center gap-6 lg:w-[80%] xl:flex-row xl:gap-8">
+      <div className="relative flex flex-col items-center gap-6 lg:w-[80%] xl:flex-row xl:gap-8">
+        <Ellipse size="md" className="bottom-[10%] right-0 rotate-[20deg]" />
         <h3 className="text-gradient-oval px-[10%] text-xl opacity-75 xl:px-0">
           Your protocol creates value when it consumes price updates. Capture this value with Oval.
         </h3>

--- a/src/components/Oval/OevCreation.tsx
+++ b/src/components/Oval/OevCreation.tsx
@@ -4,6 +4,7 @@ import gavel from "public/assets/gavel.webp";
 import sandwich from "public/assets/sandwich.webp";
 import arbitrage from "public/assets/arbitrage.webp";
 import { ExternalLink } from "./ExternalLink";
+import { Ellipse } from "./Ellipsis";
 
 const content = [
   {
@@ -34,15 +35,16 @@ const content = [
 
 export const OevCreation = () => {
   return (
-    <section className="relative mx-auto mt-12 flex max-w-[700px] flex-col items-center gap-8 px-[--page-padding] text-center align-top xl:max-w-[1300px] xl:gap-[96px]">
+    <section className="relative mx-auto mt-[200px] flex max-w-[700px] flex-col items-center gap-8 px-[--page-padding] text-center align-top xl:max-w-[1300px] xl:gap-[96px]">
       <h2 className="text-gradient-oval px-[10%] text-center text-sm-fluid md:text-md-fluid lg:text-lg-fluid">
         OEV Creation
       </h2>
-      <div className="flex flex-col gap-3 xl:flex-row xl:gap-6">
+      <div className="relative flex flex-col gap-3 xl:flex-row xl:gap-6">
         {content.map((item) => (
           <Card key={item.title} {...item} />
         ))}
       </div>
+      <Ellipse size="md" className="left-[-50%] top-0" />
       <ExternalLink aria-label="link to docs" href="https://docs.oval.xyz/integration/getting-started">
         Learn more
       </ExternalLink>

--- a/src/components/Oval/OevLost.tsx
+++ b/src/components/Oval/OevLost.tsx
@@ -5,6 +5,7 @@ import { oevLost } from "@/constant/env";
 import { Roboto_Mono } from "next/font/google";
 import { useIntersectionObserver } from "usehooks-ts";
 import { Divider } from "./Divider";
+import { Ellipse } from "./Ellipsis";
 
 // If loading a variable font, you don't need to specify the font weight
 const roboto = Roboto_Mono({
@@ -39,6 +40,7 @@ export const OevLost = () => {
 
   return (
     <section className="relative mx-auto mb-[150px] flex max-w-[828px] flex-col items-center gap-2 px-[--page-padding] text-center xl:mb-[200px]">
+      <Ellipse className="right-[-20%]" />
       <div
         style={{
           perspective: "500px",

--- a/src/components/Oval/ReclaimOev.tsx
+++ b/src/components/Oval/ReclaimOev.tsx
@@ -1,6 +1,7 @@
 import { cn } from "@/utils/styleUtils";
 import { IntegrateOvalButton } from "./IntegrateOvalModal/IntegrateOvalButton";
 import { Animation } from "./Animation";
+import { Ellipse } from "./Ellipsis";
 
 export type ReclaimOevProps = {
   className?: string;
@@ -10,7 +11,7 @@ export const ReclaimOev = ({ className }: ReclaimOevProps) => {
   return (
     <section
       className={cn(
-        "relative mx-auto mt-[128px] max-w-[1200px] flex-col items-center overflow-clip px-[--page-padding] ",
+        "relative mx-auto mt-[128px] max-w-[1200px] flex-col items-center overflow-visible px-[--page-padding] ",
         className,
       )}
     >
@@ -20,7 +21,8 @@ export const ReclaimOev = ({ className }: ReclaimOevProps) => {
           scene="https://prod.spline.design/6fMUQ-8iv1LJxomb/scene.splinecode"
         />
 
-        <div className="flex max-w-[500px] flex-1 flex-col items-center gap-8 xl:items-start">
+        <div className="relative flex max-w-[500px] flex-1 flex-col items-center gap-8 xl:items-start">
+          <Ellipse size="md" className="right-[-50%] top-[-50%] rotate-45" />
           <h2 className="text-gradient-oval whitespace-nowrap text-center text-sm-fluid md:text-md-fluid lg:text-lg-fluid xl:text-left">
             Reclaim OEV
           </h2>


### PR DESCRIPTION
To mimic light reflecting on a surface, we render these ellipses in Oval page sections for decorative effect.

## screenshots

![Screenshot 2024-01-16 at 15 53 49](https://github.com/UMAprotocol/uma.xyz/assets/51655063/1b8bbb68-844b-40ab-a992-b4138acd83d8)
