### PR TITLE
feat: add new mailchimp endpoint for oval

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,5 +37,9 @@ Storybook is deployed to [Chromatic](https://chromatic.com) via `yarn chromatic`
 - CHAIN_ID = 1 // (or 5 for goerli)
 - NODE_URLS ={"1":"<https://mainnet.infura.io/v3/xxx","5":"https://goerli.infura.io/v3/xxx"}>
 - NEXT_PUBLIC_MAILCHIMP_URL="<https://umaproject.us19.list-manage.com/subscribe/post?u={user}&id={id}&f_id={f_id}>"
+- NEXT_PUBLIC_OVAL_MAILCHIMP_URL="<https://umaproject.us19.list-manage.com/subscribe/post?u={user}&id={id}&f_id={f_id}>"
 - NEXT_PUBLIC_DEFAULT_APY=30.5
-- NEXT_PUBLIC_TVS=83M
+- NEXT_PUBLIC_TVS=83M=  // Osnap TVS shown, use formatted string
+- NEXT_PUBLIC_OEV_LOST= // backup oev value if dune is not working, use raw number
+- DUNE_API_KEY= // for getting total OEV lost
+- AIRTABLE_API_KEY=  // for capturing osnap, oval leads

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -11,6 +11,8 @@ import { Icon } from "./Icon";
 import MailChimpForm from "./MailChimpForm";
 import VoteTicker from "./VoteTicker";
 
+const mailChimpUrl = process.env.NEXT_PUBLIC_MAILCHIMP_URL ?? ""
+
 export default function Footer() {
   const id = "contact";
   const ref = useRef<HTMLDivElement>(null);
@@ -49,7 +51,7 @@ export default function Footer() {
           <h3 className="w-fit text-center text-xl text-grey-700 md:mb-8 lg:max-w-[640px] lg:text-left">
             Receive the latest UMA and OO news, straight to your inbox.
           </h3>
-          <MailChimpForm />
+          <MailChimpForm mailChimpUrl={mailChimpUrl}/>
         </div>
       </div>
       <div className="mx-auto mb-16 flex w-full max-w-[--page-width] flex-col-reverse items-center justify-between gap-6 lg:flex-row lg:gap-0">

--- a/src/components/MailChimpForm.tsx
+++ b/src/components/MailChimpForm.tsx
@@ -1,11 +1,11 @@
 import { SyntheticEvent, useState } from "react";
 import MailchimpSubscribe from "react-mailchimp-subscribe";
 
-export default function MailChimpForm() {
+export default function MailChimpForm(props:{mailChimpUrl:string}) {
   const [value, setValue] = useState("");
   return (
     <MailchimpSubscribe
-      url={process.env.NEXT_PUBLIC_MAILCHIMP_URL ?? ""}
+      url={props.mailChimpUrl}
       render={({ subscribe, status, message }) => (
         <>
           <form

--- a/src/components/Oval/FooterOval.tsx
+++ b/src/components/Oval/FooterOval.tsx
@@ -9,6 +9,8 @@ import { Icon } from "../Icon";
 import MailChimpForm from "../MailChimpForm";
 import { IntegrateOvalLink } from "./IntegrateOvalModal/IntegrateOvalButton";
 
+const ovalMailChimpUrl = process.env.NEXT_PUBLIC_OVAL_MAILCHIMP_URL ?? ""
+
 export function FooterOval() {
   const id = "contact";
   const ref = useRef<HTMLDivElement>(null);
@@ -37,7 +39,7 @@ export function FooterOval() {
           <h3 className="w-fit text-center text-xl text-text/75 md:mb-8 lg:max-w-[640px] lg:text-left">
             Receive the latest UMA Oval news, straight to your inbox.
           </h3>
-          <MailChimpForm />
+          <MailChimpForm mailChimpUrl={ovalMailChimpUrl}/>
         </div>
       </div>
       <div className="mx-auto mb-16 flex w-full max-w-[--page-width] flex-col-reverse items-center justify-between gap-6 lg:flex-row lg:gap-0">


### PR DESCRIPTION
## motivation
we want to separate out oval signups from uma signups

## changes
add a new env var specificall for mailchimp oval audience. this has already been added to vercel