### PR TITLE
fix: remove remoteplayback controls for videos

### DIFF
--- a/src/components/Home/Hero.tsx
+++ b/src/components/Home/Hero.tsx
@@ -76,6 +76,7 @@ export default function Hero() {
             loop
             muted
             playsInline
+            disableRemotePlayback
             style={{
               WebkitMaskImage: "-webkit-radial-gradient(white, black)",
               WebkitBackfaceVisibility: "hidden",

--- a/src/components/Home/HowItWorks.tsx
+++ b/src/components/Home/HowItWorks.tsx
@@ -140,7 +140,7 @@ function Step({ header, text, subText, index, isLast }: StepProps) {
         <p className="sm: text-xl">{subText}</p>
       </div>
       <div className="min-h-[400px] border border-grey-400 md:max-w-[754px] lg:col-start-3 lg:row-start-1 lg:max-w-[520px]">
-        <video className="h-full w-full object-cover" autoPlay loop muted playsInline>
+        <video className="h-full w-full object-cover" autoPlay loop muted playsInline disableRemotePlayback>
           <source src={`/assets/step-${stepNumber}.mp4`} type="video/mp4" />
           <source src={`/assets/step-${stepNumber}.webm`} type="video/webm" />
         </video>

--- a/src/components/Home/SupportSection.tsx
+++ b/src/components/Home/SupportSection.tsx
@@ -19,6 +19,7 @@ export default function SupportSection() {
           loop
           muted
           playsInline
+          disableRemotePlayback
         >
           <source src="/assets/uma.xyz.mp4" type="video/mp4" />
           <source src="/assets/uma.xyz.webm" type="video/webm" />

--- a/src/components/OsnapV2/Hero.tsx
+++ b/src/components/OsnapV2/Hero.tsx
@@ -3,13 +3,12 @@ import bgImage from "public/assets/bg-image.png";
 import { InitialLoadTryOsnapModal } from "./InitialLoadTryOsnapModal";
 import { TryOsnapButton } from "./TryOsnapButton";
 import { TvsChip } from "@/components/OsnapV2/TvsChip";
-import { totalValueSecured } from "@/constant";
 
 export function Hero() {
   return (
     <section className="-mt-[calc(var(--header-height)+var(--vote-ticker-height))] bg-white px-page-padding pb-8 pt-[150px] md:pb-12 lg:pb-[72px] lg:pt-[200px]">
       <Image src={bgImage} alt="bg image" className="absolute inset-0 isolate -z-10 h-full w-full" layout="fill" />
-      <TvsChip amount={totalValueSecured} className="mx-auto" />
+      <TvsChip className="mx-auto" />
       <h1 className="mb-3 mt-6 bg-gradient-to-r from-grey-900 to-grey-900/60 bg-clip-text text-center text-4xl font-medium text-transparent sm:text-5xl md:mb-4 md:text-6xl lg:text-7xl">
         Offchain governance.
         <br />

--- a/src/components/OsnapV2/TvsChip.tsx
+++ b/src/components/OsnapV2/TvsChip.tsx
@@ -4,12 +4,11 @@ import { duneActive } from "@/lib/constants";
 import { getOsnapTvs } from "@/lib/dune";
 import { roundToNearestMillion } from "@/utils";
 
-type TvsChipProps = GradientBorderProps & {
-  amount: string; // eg. $ 83M
-};
+type TvsChipProps = GradientBorderProps;
 
-export async function TvsChip({ amount, className, ...props }: TvsChipProps) {
+export async function TvsChip({ className, ...props }: TvsChipProps) {
   const tvs = duneActive ? roundToNearestMillion((await getOsnapTvs()).amount_usd) : parseInt(totalValueSecured);
+
   return (
     <GradientBorder hoverEffect className={className} {...props}>
       <div className="flex items-baseline gap-[0.20em] px-2 py-1 text-lg lg:text-xl">

--- a/src/components/OsnapV2/Video.tsx
+++ b/src/components/OsnapV2/Video.tsx
@@ -9,7 +9,7 @@ import { Icon } from "../Icon";
 import { TryOsnapButton } from "./TryOsnapButton";
 
 export function Video() {
-  const [videoSrc, setVideoSrc] = useState("https://www.youtube.com/embed/tj_m6XMoPO4?controls=0");
+  const [videoSrc, setVideoSrc] = useState("https://www.youtube.com/embed/tj_m6XMoPO4?controls=1");
   const [showThumbnail, setShowThumbnail] = useState(true);
 
   const onClick: MouseEventHandler<HTMLDivElement> = (e) => {

--- a/src/components/Oval/BuildSafely.tsx
+++ b/src/components/Oval/BuildSafely.tsx
@@ -16,7 +16,7 @@ export const BuildSafely = ({ className }: BuildSafelyProps) => {
     >
       <div className="flex flex-col items-center gap-8 xl:flex-row-reverse xl:justify-center xl:gap-24">
         <div className="-z-1 relative mb-[10%] aspect-[2] h-fit max-h-[300px] w-full max-w-[600px] flex-1 shrink-0">
-          <video autoPlay loop muted playsInline className="object-contain object-center">
+          <video autoPlay loop muted playsInline disableRemotePlayback className="object-contain object-center">
             <source src="assets/buildSafely.mp4" type="video/mp4" />
           </video>
         </div>

--- a/src/components/Oval/Hero.tsx
+++ b/src/components/Oval/Hero.tsx
@@ -4,7 +4,7 @@ export const Hero = () => {
   return (
     <section className="relative mx-auto mt-12 flex max-w-[828px] flex-col items-center justify-center gap-4 px-[--page-padding] pb-[94px] text-center align-top xl:pb-[128px]">
       <div className="aspect-square h-fit max-h-[400px] w-full max-w-[600px] flex-1 shrink-0 ">
-        <video className="object-cover object-center" autoPlay loop muted playsInline>
+        <video className="object-cover object-center" autoPlay loop muted playsInline disableRemotePlayback>
           <source src="assets/hero-oval.mp4" type="video/mp4" />
         </video>
       </div>

--- a/src/components/Oval/ReclaimOev.tsx
+++ b/src/components/Oval/ReclaimOev.tsx
@@ -16,7 +16,7 @@ export const ReclaimOev = ({ className }: ReclaimOevProps) => {
     >
       <div className="flex flex-col items-center gap-8 xl:flex-row xl:justify-center xl:gap-24">
         <div className="-z-1 relative aspect-[1.2] h-fit max-h-[500px] w-full max-w-[600px] flex-1 shrink-0 ">
-          <video autoPlay loop muted playsInline className="object-contain object-center">
+          <video disableRemotePlayback autoPlay loop muted playsInline className="object-contain object-center">
             <source src="assets/captureOev.mp4" type="video/mp4" />
           </video>
         </div>


### PR DESCRIPTION
## motivation

Some browsers (Chrome) now show controls to play a video in some sort of remote device, wired or wireless. In general we want users to control playback of videos, but NOT if they are purely decorative.

See below, a chromecast button appears over all video elements. I noticed this after updating Chrome so it must be a new feature.

![Screenshot 2024-01-31 at 11 04 24](https://github.com/UMAprotocol/uma.xyz/assets/51655063/581b1887-10b1-4926-928c-c011d53fa94a)

![Screenshot 2024-01-31 at 11 06 26](https://github.com/UMAprotocol/uma.xyz/assets/51655063/e518df3d-f026-4795-aaa8-22e0e85436be)
