### PR TITLE
Fix dune updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@typescript-eslint/eslint-plugin": "^6.4.0",
     "@uma/contracts-node": "^0.4.17",
     "@vercel/analytics": "^1.1.3",
+    "@vercel/kv": "^1.0.1",
     "airtable": "^0.12.2",
     "autoprefixer": "^10.4.15",
     "chromatic": "^6.22.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ dependencies:
   '@vercel/analytics':
     specifier: ^1.1.3
     version: 1.1.3
+  '@vercel/kv':
+    specifier: ^1.0.1
+    version: 1.0.1
   airtable:
     specifier: ^0.12.2
     version: 0.12.2
@@ -7097,10 +7100,23 @@ packages:
     resolution: {integrity: sha512-e7cVJr3yhKrPZn1TAo/CCOt+QacJON6Mj71lcwHq/rnx+tgjujK2MsOhihytmb79ejPTKg1b5+2GIDL02ttrrQ==}
     dev: false
 
+  /@upstash/redis@1.25.1:
+    resolution: {integrity: sha512-ACj0GhJ4qrQyBshwFgPod6XufVEfKX2wcaihsEvSdLYnY+m+pa13kGt1RXm/yTHKf4TQi/Dy2A8z/y6WUEOmlg==}
+    dependencies:
+      crypto-js: 4.2.0
+    dev: false
+
   /@vercel/analytics@1.1.3:
     resolution: {integrity: sha512-Z0l0y8TnUnnxr+on7oIMB9qQOoSJIniYMzUng6+NU8VVDkZ+kt2QGD5hzODwsuiRJAsjW528iUEtbWCEGkSCCg==}
     dependencies:
       server-only: 0.0.1
+    dev: false
+
+  /@vercel/kv@1.0.1:
+    resolution: {integrity: sha512-uTKddsqVYS2GRAM/QMNNXCTuw9N742mLoGRXoNDcyECaxEXvIHG0dEY+ZnYISV4Vz534VwJO+64fd9XeSggSKw==}
+    engines: {node: '>=14.6'}
+    dependencies:
+      '@upstash/redis': 1.25.1
     dev: false
 
   /@webassemblyjs/ast@1.11.6:
@@ -8567,6 +8583,10 @@ packages:
       public-encrypt: 4.0.3
       randombytes: 2.1.0
       randomfill: 1.0.4
+    dev: false
+
+  /crypto-js@4.2.0:
+    resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
     dev: false
 
   /crypto-random-string@2.0.0:

--- a/src/app/osnap/page.tsx
+++ b/src/app/osnap/page.tsx
@@ -1,6 +1,7 @@
 import Footer from "@/components/Footer";
 import { Layout } from "@/components/Layout";
 import { OsnapV2 } from "@/components/pages/OsnapV2";
+import { ONE_DAY_SECONDS } from "@/lib/constants";
 import { Metadata } from "next";
 
 const title = "oSnap | Secured by UMA";
@@ -23,6 +24,8 @@ export const metadata: Metadata = {
     url: "https://uma.xyz",
   },
 };
+
+export const revalidate = ONE_DAY_SECONDS;
 
 export default function Page() {
   return (

--- a/src/app/oval/page.tsx
+++ b/src/app/oval/page.tsx
@@ -3,6 +3,9 @@ import { CaptureOev, Hero, OevLost, ReclaimOev, BuildSafely, Faq, FooterOval } f
 import { Layout } from "@/components/Layout";
 import { IntegrateOvalModal } from "@/components/Oval/IntegrateOvalModal";
 import { Suspense } from "react";
+import { ONE_DAY_SECONDS } from "@/lib/constants";
+
+export const revalidate = ONE_DAY_SECONDS;
 
 const title = "Oval | Built by UMA";
 const description =

--- a/src/components/OsnapV2/Hero.tsx
+++ b/src/components/OsnapV2/Hero.tsx
@@ -8,6 +8,7 @@ export function Hero() {
     <section className="-mt-[calc(var(--header-height)+var(--vote-ticker-height))] bg-white px-page-padding pb-8 pt-[150px] md:pb-12 lg:pb-[72px] lg:pt-[200px]">
       <Image src={bgImage} alt="bg image" className="absolute inset-0 isolate -z-10 h-full w-full" layout="fill" />
       <TvsChip className="mx-auto" />
+
       <h1 className="mb-3 mt-6 bg-gradient-to-r from-grey-900 to-grey-900/60 bg-clip-text text-center text-4xl font-medium text-transparent sm:text-5xl md:mb-4 md:text-6xl lg:text-7xl">
         Offchain governance.
         <br />

--- a/src/components/OsnapV2/TvsChip.tsx
+++ b/src/components/OsnapV2/TvsChip.tsx
@@ -1,10 +1,12 @@
 import { GradientBorder, GradientBorderProps } from "@/components/GradientBorder";
 import { totalValueSecured } from "@/constant";
-import { duneActive } from "@/lib/constants";
+import { ONE_DAY_SECONDS, duneActive } from "@/lib/constants";
 import { getOsnapTvs } from "@/lib/dune";
 import { roundToNearestMillion } from "@/utils";
 
 type TvsChipProps = GradientBorderProps;
+
+export const revalidate = ONE_DAY_SECONDS;
 
 export async function TvsChip({ className, ...props }: TvsChipProps) {
   const tvs = duneActive ? roundToNearestMillion((await getOsnapTvs()).amount_usd) : parseInt(totalValueSecured);

--- a/src/components/OsnapV2/TvsChip.tsx
+++ b/src/components/OsnapV2/TvsChip.tsx
@@ -1,18 +1,16 @@
 import { GradientBorder, GradientBorderProps } from "@/components/GradientBorder";
 import { totalValueSecured } from "@/constant";
-import { ONE_DAY_SECONDS, duneActive } from "@/lib/constants";
+import { duneActive } from "@/lib/constants";
 import { getOsnapTvs } from "@/lib/dune";
 import { roundToNearestMillion } from "@/utils";
 
 type TvsChipProps = GradientBorderProps;
 
-export const revalidate = ONE_DAY_SECONDS;
-
 export async function TvsChip({ className, ...props }: TvsChipProps) {
   const tvs = duneActive ? roundToNearestMillion((await getOsnapTvs()).amount_usd) : parseInt(totalValueSecured);
 
   return (
-    <GradientBorder hoverEffect className={className} {...props}>
+    <GradientBorder className={className} {...props}>
       <div className="flex items-baseline gap-[0.20em] px-2 py-1 text-lg lg:text-xl">
         <span className="font-bold text-primary-500">${tvs}M</span>
         Total Value Secured

--- a/src/components/Oval/OevLost.tsx
+++ b/src/components/Oval/OevLost.tsx
@@ -3,9 +3,11 @@ import { Ellipse } from "./Ellipsis";
 import { Countup } from "./Countup";
 import { getOevLost } from "@/lib/dune";
 import { oevLostFallback } from "@/constant";
-import { duneActive } from "@/lib/constants";
+import { ONE_DAY_SECONDS, duneActive } from "@/lib/constants";
 import { HelpPopover } from "./HelpPopover";
 import Link from "next/link";
+
+export const revalidate = ONE_DAY_SECONDS;
 
 export const OevLost = async () => {
   const oevLost = duneActive ? (await getOevLost()).max_potential_revenue_usd : parseInt(oevLostFallback);

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -19,6 +19,11 @@ export const OSNAP_TVS_QUERY_ID = 2944802;
 // ============ QUERY KEYS (FOR REVALIDATION) =========== //
 // ====================================================== //
 
+export const createDuneQueryKey = (queryId: number) => `dune-query-${queryId}`;
+
+export const OEV_LOST_KEY = createDuneQueryKey(OEV_LOST_QUERY_ID);
+export const TVS_KEY = createDuneQueryKey(OSNAP_TVS_QUERY_ID);
+
 export const duneActive = !!Dune;
 
 export type OevLostData = {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -19,9 +19,12 @@ export const OSNAP_TVS_QUERY_ID = 2944802;
 // ============ QUERY KEYS (FOR REVALIDATION) =========== //
 // ====================================================== //
 
-export const createDuneQueryKey = (queryId: number) => `dune-query-${queryId}`;
-
-export const OEV_LOST_KEY = createDuneQueryKey(OEV_LOST_QUERY_ID);
-export const TVS_KEY = createDuneQueryKey(OSNAP_TVS_QUERY_ID);
-
 export const duneActive = !!Dune;
+
+export type OevLostData = {
+  max_potential_revenue_usd: number;
+};
+
+export type OsnapTvsData = {
+  amount_usd: number;
+};

--- a/src/lib/dune.ts
+++ b/src/lib/dune.ts
@@ -1,25 +1,41 @@
 import { cache } from "react";
-import { Dune, OEV_LOST_QUERY_ID, OSNAP_TVS_QUERY_ID, OevLostData, OsnapTvsData } from "./constants";
+import {
+  Dune,
+  OEV_LOST_KEY,
+  OEV_LOST_QUERY_ID,
+  OSNAP_TVS_QUERY_ID,
+  OevLostData,
+  OsnapTvsData,
+  TVS_KEY,
+} from "./constants";
+import { kv } from "@vercel/kv";
 
-const dune = async <TData>(queryId: number): Promise<TData> => {
-  if (!Dune) {
-    throw new Error("No API key provided for Dune");
-  }
-  const executionRes = await Dune.refresh(queryId);
-  if (!executionRes.result) {
-    throw new Error("Failed to execute query");
-  }
+const dune = async <TData>(queryId: number, queryKey: string): Promise<TData> => {
+  try {
+    if (!Dune) {
+      throw new Error("No API key provided for Dune");
+    }
+    const executionRes = await Dune.refresh(queryId);
+    if (!executionRes.result) {
+      throw new Error("Failed to execute query");
+    }
 
-  const data = executionRes.result.rows[0] as TData;
-  return data;
+    const data = executionRes.result.rows[0] as TData;
+    // update cache
+    await kv.set(queryKey, data);
+    return data;
+  } catch (error) {
+    // TODO: implement log drain for better debugging
+    return (await kv.get(queryKey)) as TData;
+  }
 };
 
 export const getOevLost = cache(async () => {
-  const newData = await dune<OevLostData>(OEV_LOST_QUERY_ID);
+  const newData = await dune<OevLostData>(OEV_LOST_QUERY_ID, OEV_LOST_KEY);
   return newData;
 });
 
 export const getOsnapTvs = cache(async () => {
-  const newData = await dune<OsnapTvsData>(OSNAP_TVS_QUERY_ID);
+  const newData = await dune<OsnapTvsData>(OSNAP_TVS_QUERY_ID, TVS_KEY);
   return newData;
 });

--- a/src/lib/dune.ts
+++ b/src/lib/dune.ts
@@ -10,7 +10,7 @@ import {
 } from "./constants";
 import { kv } from "@vercel/kv";
 
-const dune = async <TData>(queryId: number, queryKey: string): Promise<TData> => {
+export const dune = async <TData>(queryId: number, queryKey: string): Promise<TData> => {
   try {
     if (!Dune) {
       throw new Error("No API key provided for Dune");
@@ -19,7 +19,6 @@ const dune = async <TData>(queryId: number, queryKey: string): Promise<TData> =>
     if (!executionRes.result) {
       throw new Error("Failed to execute query");
     }
-
     const data = executionRes.result.rows[0] as TData;
     // update cache
     await kv.set(queryKey, data);
@@ -30,12 +29,12 @@ const dune = async <TData>(queryId: number, queryKey: string): Promise<TData> =>
   }
 };
 
-export const getOevLost = cache(async () => {
-  const newData = await dune<OevLostData>(OEV_LOST_QUERY_ID, OEV_LOST_KEY);
+export const getOsnapTvs = cache(async () => {
+  const newData = await dune<OsnapTvsData>(OSNAP_TVS_QUERY_ID, TVS_KEY);
   return newData;
 });
 
-export const getOsnapTvs = cache(async () => {
-  const newData = await dune<OsnapTvsData>(OSNAP_TVS_QUERY_ID, TVS_KEY);
+export const getOevLost = cache(async () => {
+  const newData = await dune<OevLostData>(OEV_LOST_QUERY_ID, OEV_LOST_KEY);
   return newData;
 });

--- a/src/lib/dune.ts
+++ b/src/lib/dune.ts
@@ -1,8 +1,6 @@
-"use server";
 import { cache } from "react";
 import { Dune, OEV_LOST_QUERY_ID, OSNAP_TVS_QUERY_ID, OevLostData, OsnapTvsData } from "./constants";
 
-// if this throws then the latest cache
 const dune = async <TData>(queryId: number): Promise<TData> => {
   if (!Dune) {
     throw new Error("No API key provided for Dune");

--- a/src/lib/dune.ts
+++ b/src/lib/dune.ts
@@ -1,8 +1,9 @@
-import { unstable_cache } from "next/cache";
-import { Dune, OEV_LOST_KEY, OEV_LOST_QUERY_ID, ONE_DAY_SECONDS, OSNAP_TVS_QUERY_ID, TVS_KEY } from "./constants";
+"use server";
+import { cache } from "react";
+import { Dune, OEV_LOST_QUERY_ID, OSNAP_TVS_QUERY_ID, OevLostData, OsnapTvsData } from "./constants";
 
+// if this throws then the latest cache
 const dune = async <TData>(queryId: number): Promise<TData> => {
-  "use server";
   if (!Dune) {
     throw new Error("No API key provided for Dune");
   }
@@ -15,16 +16,12 @@ const dune = async <TData>(queryId: number): Promise<TData> => {
   return data;
 };
 
-export const getOevLost = unstable_cache(
-  () => dune<{ max_potential_revenue_usd: number }>(OEV_LOST_QUERY_ID),
-  [OEV_LOST_KEY],
-  {
-    tags: [OEV_LOST_KEY],
-    revalidate: ONE_DAY_SECONDS,
-  },
-);
+export const getOevLost = cache(async () => {
+  const newData = await dune<OevLostData>(OEV_LOST_QUERY_ID);
+  return newData;
+});
 
-export const getOsnapTvs = unstable_cache(() => dune<{ amount_usd: number }>(OSNAP_TVS_QUERY_ID), [TVS_KEY], {
-  tags: [TVS_KEY],
-  revalidate: ONE_DAY_SECONDS,
+export const getOsnapTvs = cache(async () => {
+  const newData = await dune<OsnapTvsData>(OSNAP_TVS_QUERY_ID);
+  return newData;
 });


### PR DESCRIPTION
## motivation

The `unstable_cache` function does not seem to revalidate..
This PR implements react's new  `cache()` function as recommended here in nextjs docs https://nextjs.org/docs/app/building-your-application/data-fetching/fetching-caching-and-revalidating#fetching-data-on-the-server-with-third-party-libraries

We are also using Vercel's `KV` storage mechanism, which is essentially a wrapper around Upstash's Redis service. We use this is case our function to revalidate the cache throws an error.