### PR TITLE
fix:video background matching

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -3,7 +3,20 @@ import Header from "./Header";
 import VoteTicker from "./VoteTicker";
 import { PortalContainer } from "./Portal";
 import OvalBanner from "./OvalBanner";
-import { Page, Pages } from "@/constant/pages";
+import { Page, Pages, Platforms } from "@/constant/pages";
+import { headers } from "next/headers";
+
+const platformsColorA = ["windows", "iphone", "ipad"];
+
+const getPlatform = () => {
+  const headersList = headers();
+  const ua = headersList.get("user-agent");
+
+  const platform = platformsColorA.some((platform) => ua?.toLowerCase()?.includes(platform))
+    ? Platforms.WINDOWS
+    : Platforms.MAC;
+  return platform;
+};
 
 export type LayoutProps = {
   children: React.ReactNode;
@@ -21,7 +34,11 @@ export function Layout({
   className,
 }: LayoutProps) {
   return (
-    <main data-color-scheme={page.toLowerCase()} className={cn("relative h-[100%] overflow-clip", className)}>
+    <main
+      data-platform={getPlatform().toLowerCase()}
+      data-color-scheme={page.toLowerCase()}
+      className={cn("relative h-[100%] overflow-clip", className)}
+    >
       {showOvalBanner && <OvalBanner page={page} />}
       {showTicker && <VoteTicker className="z-20" />}
       <Header />

--- a/src/components/Oval/OevLost.tsx
+++ b/src/components/Oval/OevLost.tsx
@@ -15,7 +15,7 @@ export const OevLost = async () => {
   return (
     <section className="relative mx-auto mb-[150px] flex max-w-[828px] flex-col items-center gap-2 px-[--page-padding] text-center xl:mb-[200px]">
       <Ellipse className="right-[-20%]" />
-      <h3 className="flex items-center justify-center gap-1 text-sm uppercase leading-6 tracking-widest text-white/50 md:text-base lg:text-lg">
+      <h3 className="text-sm uppercase leading-6 tracking-widest text-white/50 md:text-base lg:text-lg">
         MAINNET OEV LEAKED BY AAVE V2 & V3, COMPOUND V2 & V3{" "}
         <HelpPopover
           text={

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -31,6 +31,15 @@ body:has(main[data-color-scheme="osnap"]) {
   --text-base: 0 0% 0%;
 }
 
+body:has(main[data-color-scheme="oval"][data-platform="mac"]) {
+  --background-base: 0 0% 13.8%;
+}
+
+body:has(main[data-color-scheme="oval"][data-platform="windows"]) {
+  --background-base: 0 0% 12%;
+  --text-base: 0 0% 100%;
+}
+
 html {
   /* Making sure text size is only controlled by font-size */
   -webkit-text-size-adjust: none;


### PR DESCRIPTION
## motivation

After another chrome upgrade it seems the way the background colors are rendered on mac/chrome has changed again. Since we can not change the color range used by these videos and re-export them, we have to hack together a solution that checks the user agent and sets the background of the page to to match the video's background.