### PR TITLE
improve: darken email input color

### DIFF
--- a/src/components/MailChimpForm.tsx
+++ b/src/components/MailChimpForm.tsx
@@ -17,7 +17,7 @@ export default function MailChimpForm(props:{mailChimpUrl:string}) {
             }}
           >
             <input
-              className="h-12 w-full max-w-[528px] rounded-lg border-2 border-[transparent] bg-white px-4 py-3 text-lg text-grey-200 caret-grey-900 outline-none transition hover:border-grey-500 focus:border-grey-900 xl:max-w-[350px]"
+              className="h-12 w-full max-w-[528px] rounded-lg border-2 border-[transparent] bg-white px-4 py-3 text-lg text-grey-200 caret-grey-900 outline-none transition hover:border-grey-500 focus:border-grey-900 xl:max-w-[350px] text-grey-900"
               type="email"
               name="email"
               value={value}


### PR DESCRIPTION
## motivation
text looks grayed out when entering email in this form 
![image](https://github.com/UMAprotocol/uma.xyz/assets/4429761/1de495c2-cce0-4985-b9e1-8a6ca2de150b)

## changes
just adds darker text color 
![image](https://github.com/UMAprotocol/uma.xyz/assets/4429761/8d2ea31d-5de8-4b98-8e1c-986fbad2b691)
