### PR TITLE
inline links, use osnap modal trigger, better transitions

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -76,10 +76,12 @@ function LinksList({ links }: { links: { label: string; href: string }[] }) {
           <NextLink
             href={href}
             target={isExternalLink(href) ? "_blank" : undefined}
-            className="flex items-center gap-1 transition-all hover:gap-[2px] hover:brightness-200"
+            className="group flex items-center gap-1 transition-all hover:brightness-200"
           >
             {label}
-            {isExternalLink(href) && <Icon name="arrow" className=" h-4 w-4 -rotate-45" />}
+            {isExternalLink(href) && (
+              <Icon name="arrow" className="h-4 w-4 -rotate-45 transition-transform group-hover:-translate-x-[3px]" />
+            )}
           </NextLink>
         </li>
       ))}

--- a/src/components/OsnapV2/Faq.tsx
+++ b/src/components/OsnapV2/Faq.tsx
@@ -2,6 +2,7 @@
 
 import { Accordion } from "../Accordion";
 import NextLink from "next/link";
+import { TryOsnapModalTrigger } from "../Osnap/TryOsnapModal";
 
 export function Faq() {
   const faqs = [
@@ -19,14 +20,13 @@ export function Faq() {
           open-source monitoring bots. Your community can get involved by running their own bots and monitoring oSnap
           directly through the{" "}
           <NextLink
-            className="items-center text-red transition hover:opacity-50"
+            className="inline items-center text-red transition hover:opacity-50"
             href="https://vote.uma.xyz/"
             target="_blank"
             aria-label="Link to voter dapp"
           >
-            UMA Voter dapp
+            UMA Voter dapp.
           </NextLink>
-          .
         </>
       ),
     },
@@ -37,7 +37,7 @@ export function Faq() {
           Voting offchain in Snapshot is gasless, making it free to use and much easier for your community to
           participate. Offchain proposals get approximately{" "}
           <NextLink
-            className="items-center text-red transition hover:opacity-50"
+            className="inline items-center text-red transition hover:opacity-50"
             href="https://dune.com/risk_labs/onchain-vs-offchain-voting"
             target="_blank"
             aria-label="Link to dune analytics dashboard"
@@ -74,16 +74,9 @@ export function Faq() {
         <>
           oSnap is live on Arbitrum, Ethereum, Optimism and Polygon. If you want oSnap support on other EVM chains,
           speak to our{" "}
-          <NextLink
-            className="items-center text-red transition hover:opacity-50"
-            href={{
-              pathname: "/osnap",
-              query: { modal: "try-osnap" },
-            }}
-            aria-label="Link to open DAO support modal."
-          >
+          <TryOsnapModalTrigger className="inline items-center text-red transition hover:opacity-50">
             integrations team
-          </NextLink>
+          </TryOsnapModalTrigger>
           .
         </>
       ),

--- a/src/components/OsnapV2/TryOsnapButton.tsx
+++ b/src/components/OsnapV2/TryOsnapButton.tsx
@@ -3,14 +3,15 @@ import { TryOsnapModalTrigger } from "../Osnap/TryOsnapModal";
 
 type Props = {
   className?: string;
+  children?: React.ReactNode;
 };
 
-export function TryOsnapButton({ className }: Props) {
+export function TryOsnapButton({ className, children }: Props) {
   return (
     <TryOsnapModalTrigger
       className={cn("mx-auto block w-fit rounded-xl bg-grey-900 px-4 py-3 text-lg font-medium text-white", className)}
     >
-      Try oSnap
+      {children ?? "Try oSnap"}
     </TryOsnapModalTrigger>
   );
 }

--- a/src/components/OsnapV2/Video.tsx
+++ b/src/components/OsnapV2/Video.tsx
@@ -61,8 +61,12 @@ export function Video() {
             href="https://docs.uma.xyz/developers/osnap/osnap-quick-start"
             className="bg-grey-white group mx-auto grid h-16 w-full place-items-center rounded-xl border border-grey-200 px-4 text-lg font-medium text-grey-600"
           >
-            <span className="flex items-center gap-1 transition-all group-hover:gap-[1.5px] group-hover:brightness-150">
-              Read Docs <Icon name="external-link" className="inline h-5 w-5" />
+            <span className="flex items-center gap-1 transition-all  group-hover:brightness-150">
+              Read Docs{" "}
+              <Icon
+                name="external-link"
+                className="inline h-5 w-5 transition-transform group-hover:translate-x-[2px]"
+              />
             </span>
           </Link>
         </div>

--- a/src/components/Oval/Faq.tsx
+++ b/src/components/Oval/Faq.tsx
@@ -45,7 +45,7 @@ export const Faq = () => {
           No, Oval simply delivers the price it received from the Chainlink Data Feed. Oval has been audited by
           OpenZeppelin to ensure that prices can&apos;t be manipulated. Oval is also subject to the same{" "}
           <Link
-            className="items-center text-red transition hover:opacity-50"
+            className="inline items-center text-red transition hover:opacity-50"
             target="_blank"
             aria-label="Link to UMA docs"
             href="https://docs.uma.xyz/resources/audit-and-bug-bounty-programs"
@@ -63,7 +63,7 @@ export const Faq = () => {
           Oval has been designed to wrap and relay prices from Chainlink Data Feeds without introducing risks not
           present in the underlying feed. For a full explanation of this please consult the{" "}
           <Link
-            className="items-center text-red transition hover:opacity-50"
+            className="inline items-center text-red transition hover:opacity-50"
             target="_blank"
             aria-label="Link to UMA docs"
             href="https://docs.oval.xyz/mechanism-design/trust-assumptions"
@@ -81,7 +81,7 @@ export const Faq = () => {
           50% of the OEV is directed to an address specified by the protocol that originally generated the revenue. The
           remaining 50% is allocated to UMA and its partners. You can learn more about revenue sharing in our{" "}
           <Link
-            className="items-center text-red transition hover:opacity-50"
+            className="inline items-center text-red transition hover:opacity-50"
             target="_blank"
             aria-label="Link to UMA docs"
             href="https://docs.oval.xyz/mechanism-details/revenue-sharing"
@@ -117,7 +117,7 @@ export const Faq = () => {
         defaultValue="0"
       />
       <Link
-        className=" justify-self-end whitespace-nowrap rounded-lg bg-red px-6 py-4 text-lg text-background no-underline transition hover:opacity-75 xl:w-fit"
+        className="inline justify-self-end whitespace-nowrap rounded-lg bg-red px-6 py-4 text-lg text-background no-underline transition hover:opacity-75 xl:w-fit"
         href="https://docs.oval.xyz/"
         target="_blank"
       >

--- a/src/components/Oval/OevLost.tsx
+++ b/src/components/Oval/OevLost.tsx
@@ -22,7 +22,7 @@ export const OevLost = async () => {
             <p>
               For more information about UMA&apos;s theoretical historic OEV methodology, please see the{" "}
               <Link
-                className="items-center text-red transition hover:opacity-50"
+                className="inline items-center text-red transition hover:opacity-50"
                 target="_blank"
                 href="https://docs.oval.xyz/oev-data"
               >


### PR DESCRIPTION
## motivation

Some minor style changes. 
- Ensure inline links are explicitly set to `display: inline`
- Ensure we use the proper `OsnapModalTrigger` and not just a link.
- Less janky transitions when hovering on links

 example of link that is not `inline`
![Screenshot 2024-04-11 at 12 53 42](https://github.com/UMAprotocol/uma.xyz/assets/51655063/edf96375-d58e-4056-9f0c-8397e4de57e5)

fixed
![Screenshot 2024-04-11 at 12 56 29](https://github.com/UMAprotocol/uma.xyz/assets/51655063/7cddcf4d-41ea-45df-a29d-86df8e73e15b)

