### PR TITLE
fix: next cache is serving stale values for TVS on all routes

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,9 @@ import "@/styles/sandpack-override.css";
 import { Analytics } from "@vercel/analytics/react";
 import { GoogleAnalytics } from "@next/third-parties/google";
 import { GA_TAG } from "@/constant";
+import { ONE_DAY_SECONDS } from "@/lib/constants";
+
+export const revalidate = ONE_DAY_SECONDS;
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (

--- a/src/app/oval/page.tsx
+++ b/src/app/oval/page.tsx
@@ -12,6 +12,13 @@ const description =
   "Oval is an MEV capture technology that wraps price oracles and generates protocol revenue by auctioning the right to conduct liquidations";
 
 export const metadata: Metadata = {
+  metadataBase: new URL("https://uma.xyz"),
+  alternates: {
+    canonical: "/",
+    languages: {
+      "en-US": "/en-US",
+    },
+  },
   title,
   description,
   twitter: {
@@ -24,7 +31,7 @@ export const metadata: Metadata = {
     title,
     description,
     images: "/assets/oval-twitter-card.jpg",
-    url: "https://uma.xyz/oval",
+    url: "/oval",
   },
 };
 

--- a/src/components/Home/OracleTvsChip.tsx
+++ b/src/components/Home/OracleTvsChip.tsx
@@ -1,5 +1,4 @@
-import { totalValueSecured } from "@/constant";
-import { ONE_DAY_SECONDS, duneActive } from "@/lib/constants";
+import { ONE_DAY_SECONDS } from "@/lib/constants";
 import { getOracleTvs } from "@/lib/dune";
 import { roundToNearestMillion } from "@/utils";
 import { cn } from "@/utils/styleUtils";
@@ -11,7 +10,7 @@ type TvsChipProps = {
 };
 
 export async function OracleTvsChip({ className }: TvsChipProps) {
-  const tvs = duneActive ? roundToNearestMillion(await getOracleTvs()) : parseInt(totalValueSecured);
+  const tvs = await getOracleTvs();
 
   return (
     <div
@@ -22,7 +21,7 @@ export async function OracleTvsChip({ className }: TvsChipProps) {
     >
       <div className="rounded-2xl border border-white/5 p-1">
         <div className="flex items-baseline gap-[0.20em] rounded-xl border border-white/5 bg-transparent px-3 py-2 text-xl text-white lg:text-2xl">
-          <span className="font-normal text-primary-500">${tvs}M</span>
+          <span className="font-normal text-primary-500">${roundToNearestMillion(tvs)}</span>
           Total Value Secured
         </div>
       </div>

--- a/src/components/OsnapV2/OsnapTvsChip.tsx
+++ b/src/components/OsnapV2/OsnapTvsChip.tsx
@@ -1,6 +1,5 @@
 import { GradientBorder, GradientBorderProps } from "@/components/GradientBorder";
-import { totalValueSecured } from "@/constant";
-import { ONE_DAY_SECONDS, duneActive } from "@/lib/constants";
+import { ONE_DAY_SECONDS } from "@/lib/constants";
 import { getOsnapTvs } from "@/lib/dune";
 import { roundToNearestMillion } from "@/utils";
 
@@ -9,12 +8,12 @@ export const revalidate = ONE_DAY_SECONDS;
 type TvsChipProps = GradientBorderProps;
 
 export async function OsnapTvsChip({ className, ...props }: TvsChipProps) {
-  const tvs = duneActive ? roundToNearestMillion(await getOsnapTvs()) : parseInt(totalValueSecured);
+  const tvs = await getOsnapTvs();
 
   return (
     <GradientBorder className={className} {...props}>
       <div className="flex items-baseline gap-[0.20em] px-2 py-1 text-lg lg:text-xl">
-        <span className="font-bold text-primary-500">${tvs}M</span>
+        <span className="font-bold text-primary-500">${roundToNearestMillion(tvs)}</span>
         Total Value Secured
       </div>
     </GradientBorder>

--- a/src/components/Oval/OevLost.tsx
+++ b/src/components/Oval/OevLost.tsx
@@ -2,15 +2,14 @@ import { Divider } from "./Divider";
 import { Ellipse } from "./Ellipsis";
 import { Countup } from "./Countup";
 import { getOevLost } from "@/lib/dune";
-import { oevLostFallback } from "@/constant";
-import { ONE_DAY_SECONDS, duneActive } from "@/lib/constants";
+import { ONE_DAY_SECONDS } from "@/lib/constants";
 import { HelpPopover } from "./HelpPopover";
 import Link from "next/link";
 
 export const revalidate = ONE_DAY_SECONDS;
 
 export const OevLost = async () => {
-  const oevLost = duneActive ? await getOevLost() : parseInt(oevLostFallback);
+  const oevLost = await getOevLost();
 
   return (
     <section className="relative mx-auto mb-[150px] flex max-w-[828px] flex-col items-center gap-2 px-[--page-padding] text-center xl:mb-[200px]">

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -14,7 +14,7 @@ export const ONE_DAY_SECONDS = 86_400;
 
 export const OEV_LOST_QUERY_ID = 3373179;
 export const OSNAP_TVS_QUERY_ID = 2944802;
-export const ORACLE_TVS_QUERY_ID = 3108786;
+export const ORACLE_TVS_QUERY_ID = 3113313;
 
 // ====================================================== //
 // ============ QUERY KEYS (FOR REVALIDATION) =========== //

--- a/src/lib/dune.ts
+++ b/src/lib/dune.ts
@@ -15,6 +15,7 @@ import { kv } from "@vercel/kv";
 
 export const dune = async <TData>(queryId: number, queryKey: string): Promise<TData> => {
   try {
+    console.log("attempting update");
     if (!Dune) {
       throw new Error("No API key provided for Dune");
     }
@@ -22,12 +23,14 @@ export const dune = async <TData>(queryId: number, queryKey: string): Promise<TD
     if (!executionRes.result) {
       throw new Error("Failed to execute query");
     }
+    console.log("dune update successful");
     const data = executionRes.result.rows[0] as TData;
     // update cache
     await kv.set(queryKey, data);
+    console.log("redis update successful, new value: ");
     return data;
   } catch (error) {
-    // TODO: implement log drain for better debugging
+    console.error(error);
     return (await kv.get(queryKey)) as TData;
   }
 };

--- a/src/lib/dune.ts
+++ b/src/lib/dune.ts
@@ -15,7 +15,6 @@ import { kv } from "@vercel/kv";
 
 export const dune = async <TData>(queryId: number, queryKey: string): Promise<TData> => {
   try {
-    console.log("attempting update");
     if (!Dune) {
       throw new Error("No API key provided for Dune");
     }

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -23,8 +23,8 @@ export function wait(timeoutMilliseconds: number) {
 export function roundToNearestMillion(value: number): string {
   const mil = value / 1_000_000;
   if (mil < 1_000) {
-    return Math.round(mil).toLocaleString();
+    return `${Math.round(mil).toLocaleString()}M`;
   }
   const bil = mil / 1_000;
-  return Math.round(bil).toLocaleString();
+  return `${bil.toFixed(2)}B`;
 }

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -21,6 +21,10 @@ export function wait(timeoutMilliseconds: number) {
 }
 
 export function roundToNearestMillion(value: number): string {
-  const nearestMillion = Math.round(value / 1_000_000);
-  return nearestMillion.toLocaleString();
+  const mil = value / 1_000_000;
+  if (mil < 1_000) {
+    return Math.round(mil).toLocaleString();
+  }
+  const bil = mil / 1_000;
+  return Math.round(bil).toLocaleString();
 }


### PR DESCRIPTION
## motivation

Caching seems to be broken on our corporate site. The TVS values are not updating every day, as they should.

Work done:
- Ensure we revalidate all routes, once a day. 
- Format billions for the home page, use the correct tvs figure from Dune (oSnap + Oracle TVS)