### PR TITLE
fix: rename oracle to optimistic oracle in footer

### DIFF
--- a/src/constant/links.tsx
+++ b/src/constant/links.tsx
@@ -116,7 +116,7 @@ export const footerLinks = {
   ],
   external: [
     {
-      label: "Oracle",
+      label: "Optimistic Oracle (OO)",
       href: "https://oracle.uma.xyz/",
     },
     {


### PR DESCRIPTION
# motivation
we want to rename instances of oracle to optimistic oracle

# changes 
only changes the footer from oracle to optimistic oracle