### PR TITLE
Remove Medium link from footer

### DIFF
--- a/src/constant/links.tsx
+++ b/src/constant/links.tsx
@@ -28,11 +28,6 @@ export const socialLinks = [
     label: "Discord",
   },
   {
-    href: "https://medium.com/uma-project",
-    icon: "medium",
-    label: "Medium",
-  },
-  {
     href: "https://twitter.com/UMAprotocol",
     icon: "twitter-x",
     label: "Twitter",


### PR DESCRIPTION
Removes the **Medium** social icon + link from the footer, per James's request in Slack.

Linear: [UMA-3031](https://linear.app/uma/issue/UMA-3031/remove-medium-icon-and-link-from-umaxyz-footer)

### What changed
- Dropped the `Medium` entry from the shared `socialLinks` array in `src/constant/links.tsx`.

### Note on scope
`socialLinks` is the single source for the social-icon row in **both** the footer (`Footer.tsx`) and the mobile menu (`Header/MobileMenu.tsx`), so this removes Medium from both spots. Keeping it in one but not the other would be inconsistent. If footer-only was intended, let me know and I'll scope it down.

The unused `medium` symbol remains in `public/assets/icons.svg` (dead asset, harmless) and is left untouched to keep the diff minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)